### PR TITLE
fix: ZwiftToolApplicationTests.contextLoads fails with WorkoutRepository bean error (#45)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,4 +1,14 @@
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
+# In-memory H2 database for the test context.
+# All three JPA auto-configurations run normally so that Spring Data repository
+# bean definitions are registered. @MockitoBean fields in the test class then
+# replace those beans with mocks before any service attempts constructor injection.
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Disable schema validation so Hibernate does not attempt DDL against H2.
+spring.jpa.hibernate.ddl-auto=none
 
 app.jwt.secret=test-secret-key-that-is-long-enough-for-hmac-sha256-signing
 app.cors.allowed-origin=http://localhost:5173


### PR DESCRIPTION
## Issue
Closes #45 — ZwiftToolApplicationTests.contextLoads fails with WorkoutRepository bean error

## What was done
- Diagnosed root cause: `src/test/resources/application.properties` excluded `DataSourceAutoConfiguration`, `HibernateJpaAutoConfiguration`, and `JpaRepositoriesAutoConfiguration` to avoid a real DB connection, which prevented Spring Data from registering repository bean definitions — `WorkoutRepository` was never available for injection
- Replaced the exclusion approach with an in-memory H2 datasource (`jdbc:h2:mem:testdb`, `ddl-auto=none`), allowing full JPA repository infrastructure to initialise normally
- Added H2 as a `test` scope dependency in `pom.xml`

## Tests added
None — the existing `ZwiftToolApplicationTests.contextLoads` test is the acceptance criterion. It now passes: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`.

## Needs manual testing
None — fully covered by the context load test.

## Areas affected
**backend** — `pom.xml`, `src/test/resources/application.properties`