### PR TITLE
chore: Exclude UserDetailsServiceAutoConfiguration to suppress dev password warning (#78)

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASS}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,4 +1,4 @@
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration,org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
 
 app.jwt.secret=test-secret-key-that-is-long-enough-for-hmac-sha256-signing
 app.cors.allowed-origin=http://localhost:5173


### PR DESCRIPTION
## Issue
Closes #78 — Fix: Exclude UserDetailsServiceAutoConfiguration to suppress dev password warning

## What was done
- Added `spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration` to `application.properties` (both main and test — test properties override main, so both require the entry)
- Eliminates the spurious 'Using generated security password' warning on every startup; the auto-configured in-memory `UserDetailsService` is never used since Zwift Tool uses a custom JWT filter chain

## Tests added
None — single configuration property change; auth endpoint behaviour requires a live server. `ZwiftToolApplicationTests.contextLoads` confirmed the application context loads cleanly after the change.

## Needs manual testing
- Start the application and confirm the generated security password warning no longer appears in startup logs
- Confirm `POST /auth/signup`, `POST /auth/signin`, `POST /auth/refresh`, and `POST /auth/signout` continue to work correctly
- Confirm `GET /health` remains publicly accessible
- Confirm all protected endpoints (e.g. `GET /workouts`) still reject unauthenticated requests with 401

## Areas affected
**backend** — `src/main/resources/application.properties`, `src/test/resources/application.properties`