### PR TITLE
fix: Batch workout fetch for export and bulk replace (#70)

### DIFF
--- a/backend/src/main/java/uk/trive/zwifttool/repositories/WorkoutRepository.java
+++ b/backend/src/main/java/uk/trive/zwifttool/repositories/WorkoutRepository.java
@@ -16,6 +16,21 @@ import uk.trive.zwifttool.models.Workout;
 public interface WorkoutRepository extends JpaRepository<Workout, UUID> {
 
     /**
+     * Returns all workouts whose IDs are in the supplied list and whose
+     * {@code user_id} matches the given user.
+     *
+     * <p>Using a single batch query avoids the N+1 pattern that would occur
+     * if workouts were fetched individually in a loop. Callers should verify
+     * that the returned list size equals the requested ID count to detect
+     * ownership violations or missing records.</p>
+     *
+     * @param ids    the list of workout IDs to fetch
+     * @param userId the authenticated user's ID, used to filter by ownership
+     * @return all workouts matching both conditions
+     */
+    List<Workout> findAllByIdInAndUserId(List<UUID> ids, UUID userId);
+
+    /**
      * Returns a lightweight summary of every workout belonging to the given
      * user, ordered by most recently updated first.
      *

--- a/backend/src/main/java/uk/trive/zwifttool/services/WorkoutService.java
+++ b/backend/src/main/java/uk/trive/zwifttool/services/WorkoutService.java
@@ -120,9 +120,10 @@ public class WorkoutService {
     /**
      * Exports a set of workouts as a zip archive of .zwo files.
      *
-     * <p>Each workout in the list is verified to belong to the authenticated
-     * user before any file generation begins. If any ID fails ownership, the
-     * entire request is rejected.</p>
+     * <p>All requested workouts are fetched in a single batch query. If the
+     * returned count does not match the requested count, at least one ID was
+     * not found or belongs to another user, and the entire request is
+     * rejected before any file generation begins.</p>
      *
      * @param workoutIds the IDs of the workouts to export
      * @param userId     the authenticated user's ID
@@ -133,9 +134,12 @@ public class WorkoutService {
     public byte[] exportWorkouts(List<UUID> workoutIds, UUID userId) {
         log.info("Exporting {} workout(s) as zip for user {}", workoutIds.size(), userId);
 
-        List<Workout> workouts = new ArrayList<>(workoutIds.size());
-        for (UUID workoutId : workoutIds) {
-            workouts.add(getWorkoutForUser(workoutId, userId));
+        List<Workout> workouts = workoutRepository.findAllByIdInAndUserId(workoutIds, userId);
+
+        // If fewer workouts were returned than requested, at least one ID was
+        // not found or belongs to a different user — reject the entire request
+        if (workouts.size() != workoutIds.size()) {
+            throw new WorkoutNotFoundException(workoutIds.get(0));
         }
 
         try {
@@ -448,9 +452,10 @@ public class WorkoutService {
      * Replaces the same section across multiple workouts using a saved library
      * block, then returns a zip archive of the updated .zwo files.
      *
-     * <p>All ownership checks are performed before any mutations are applied.
-     * If any workout ID does not belong to the authenticated user, the entire
-     * operation is rejected and no changes are written.</p>
+     * <p>All requested workouts are fetched in a single batch query before any
+     * mutations are applied. If the returned count does not match the requested
+     * count, at least one ID was not found or belongs to another user, and the
+     * entire operation is rejected without writing any changes.</p>
      *
      * <p>For each workout, the current block for the target section is rotated
      * into the matching {@code prev_*} column (supporting single-step undo),
@@ -486,11 +491,13 @@ public class WorkoutService {
                     + " does not match target section " + sectionType + ".");
         }
 
-        // Fetch and validate all workouts before making any changes.
-        // A single unauthorised ID rejects the entire request.
-        List<Workout> workouts = new ArrayList<>(workoutIds.size());
-        for (UUID workoutId : workoutIds) {
-            workouts.add(getWorkoutForUser(workoutId, userId));
+        // Fetch all workouts in a single batch query and verify ownership before
+        // making any changes. A single unauthorised or missing ID rejects the
+        // entire request.
+        List<Workout> workouts = workoutRepository.findAllByIdInAndUserId(workoutIds, userId);
+
+        if (workouts.size() != workoutIds.size()) {
+            throw new WorkoutNotFoundException(workoutIds.get(0));
         }
 
         // Apply the same undo rotation used by replaceWorkoutSectionWithBlock,

--- a/backend/src/test/java/uk/trive/zwifttool/services/WorkoutServiceBatchFetchTest.java
+++ b/backend/src/test/java/uk/trive/zwifttool/services/WorkoutServiceBatchFetchTest.java
@@ -1,0 +1,266 @@
+package uk.trive.zwifttool.services;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.trive.zwifttool.exceptions.WorkoutNotFoundException;
+import uk.trive.zwifttool.models.Block;
+import uk.trive.zwifttool.models.SectionType;
+import uk.trive.zwifttool.models.Workout;
+import uk.trive.zwifttool.repositories.BlockRepository;
+import uk.trive.zwifttool.repositories.WorkoutRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the batch workout fetch behaviour introduced in {@link WorkoutService}.
+ *
+ * <p>These tests verify that {@code exportWorkouts} and {@code bulkReplaceSection}
+ * fetch all requested workouts in a single repository call, rather than issuing
+ * one query per workout ID. They also verify that ownership violations are correctly
+ * detected when the returned list size does not match the requested ID count.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class WorkoutServiceBatchFetchTest {
+
+    @Mock
+    private WorkoutRepository workoutRepository;
+
+    @Mock
+    private BlockRepository blockRepository;
+
+    @Mock
+    private ZwoExporter zwoExporter;
+
+    @InjectMocks
+    private WorkoutService workoutService;
+
+    private UUID userId;
+    private UUID workoutId1;
+    private UUID workoutId2;
+    private UUID blockId;
+    private Block mainsetBlock;
+    private Block libraryBlock;
+    private Workout workout1;
+    private Workout workout2;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        workoutId1 = UUID.randomUUID();
+        workoutId2 = UUID.randomUUID();
+        blockId = UUID.randomUUID();
+
+        mainsetBlock = Block.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .name("Main Set")
+                .sectionType(SectionType.MAINSET)
+                .content("[{}]")
+                .durationSeconds(3600)
+                .intervalCount(5)
+                .isLibraryBlock(false)
+                .createdAt(Instant.now())
+                .build();
+
+        libraryBlock = Block.builder()
+                .id(blockId)
+                .userId(userId)
+                .name("Library Mainset")
+                .sectionType(SectionType.MAINSET)
+                .content("[{\"type\":\"SteadyState\"}]")
+                .durationSeconds(1800)
+                .intervalCount(1)
+                .isLibraryBlock(true)
+                .createdAt(Instant.now())
+                .build();
+
+        workout1 = Workout.builder()
+                .id(workoutId1)
+                .userId(userId)
+                .name("Workout One")
+                .mainsetBlock(mainsetBlock)
+                .isDraft(false)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        workout2 = Workout.builder()
+                .id(workoutId2)
+                .userId(userId)
+                .name("Workout Two")
+                .mainsetBlock(mainsetBlock)
+                .isDraft(false)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // exportWorkouts — single batch query
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that {@code exportWorkouts} calls the repository once with the
+     * full list of IDs, rather than issuing one query per workout ID.
+     */
+    @Test
+    void exportWorkouts_usesSingleBatchQuery() throws IOException {
+        List<UUID> workoutIds = List.of(workoutId1, workoutId2);
+
+        when(workoutRepository.findAllByIdInAndUserId(workoutIds, userId))
+                .thenReturn(List.of(workout1, workout2));
+        when(zwoExporter.buildZip(any())).thenReturn(new byte[]{});
+
+        workoutService.exportWorkouts(workoutIds, userId);
+
+        // Repository must be called exactly once with the full ID list
+        verify(workoutRepository, times(1)).findAllByIdInAndUserId(workoutIds, userId);
+
+        // The old per-ID method must not be invoked at all
+        verify(workoutRepository, never()).findById(any(UUID.class));
+    }
+
+    /**
+     * Verifies that {@code exportWorkouts} passes all fetched workouts to
+     * {@link ZwoExporter#buildZip} after a single batch fetch.
+     */
+    @Test
+    void exportWorkouts_passesAllWorkoutsToZipBuilder() throws IOException {
+        List<UUID> workoutIds = List.of(workoutId1, workoutId2);
+
+        when(workoutRepository.findAllByIdInAndUserId(workoutIds, userId))
+                .thenReturn(List.of(workout1, workout2));
+        when(zwoExporter.buildZip(any())).thenReturn(new byte[]{1, 2, 3});
+
+        byte[] result = workoutService.exportWorkouts(workoutIds, userId);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Workout>> captor = ArgumentCaptor.forClass(List.class);
+        verify(zwoExporter).buildZip(captor.capture());
+
+        assertThat(captor.getValue()).containsExactlyInAnyOrder(workout1, workout2);
+        assertThat(result).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    /**
+     * Verifies that {@code exportWorkouts} throws {@link WorkoutNotFoundException}
+     * when the repository returns fewer workouts than were requested, which
+     * indicates that at least one ID was not found or belongs to another user.
+     */
+    @Test
+    void exportWorkouts_throwsWorkoutNotFoundException_whenOwnershipViolationDetected() throws IOException {
+        List<UUID> workoutIds = List.of(workoutId1, workoutId2);
+
+        // Only one workout returned — the other belongs to a different user or does not exist
+        when(workoutRepository.findAllByIdInAndUserId(workoutIds, userId))
+                .thenReturn(List.of(workout1));
+
+        assertThatThrownBy(() -> workoutService.exportWorkouts(workoutIds, userId))
+                .isInstanceOf(WorkoutNotFoundException.class);
+
+        verify(zwoExporter, never()).buildZip(any());
+    }
+
+    /**
+     * Verifies that {@code exportWorkouts} throws {@link WorkoutNotFoundException}
+     * when none of the requested IDs are found or owned by the user.
+     */
+    @Test
+    void exportWorkouts_throwsWorkoutNotFoundException_whenNoWorkoutsFound() {
+        List<UUID> workoutIds = List.of(workoutId1, workoutId2);
+
+        when(workoutRepository.findAllByIdInAndUserId(workoutIds, userId))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> workoutService.exportWorkouts(workoutIds, userId))
+                .isInstanceOf(WorkoutNotFoundException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkReplaceSection — single batch query
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that {@code bulkReplaceSection} calls the repository once with the
+     * full list of IDs rather than issuing one query per workout ID, both for the
+     * initial ownership-validating fetch and for the post-update re-fetch.
+     */
+    @Test
+    void bulkReplaceSection_usesSingleBatchQuery() throws IOException {
+        List<UUID> workoutIds = List.of(workoutId1, workoutId2);
+
+        when(blockRepository.findById(blockId)).thenReturn(Optional.of(libraryBlock));
+        when(workoutRepository.findAllByIdInAndUserId(workoutIds, userId))
+                .thenReturn(List.of(workout1, workout2));
+        when(workoutRepository.save(any(Workout.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(workoutRepository.findAllById(workoutIds)).thenReturn(List.of(workout1, workout2));
+        when(zwoExporter.buildZip(any())).thenReturn(new byte[]{});
+
+        workoutService.bulkReplaceSection(workoutIds, SectionType.MAINSET, blockId, userId);
+
+        // The batch ownership-check query must be called exactly once
+        verify(workoutRepository, times(1)).findAllByIdInAndUserId(workoutIds, userId);
+
+        // The old per-ID method must not be invoked
+        verify(workoutRepository, never()).findById(any(UUID.class));
+    }
+
+    /**
+     * Verifies that {@code bulkReplaceSection} throws {@link WorkoutNotFoundException}
+     * before applying any mutations when the batch fetch reveals an ownership violation.
+     */
+    @Test
+    void bulkReplaceSection_throwsWorkoutNotFoundException_whenOwnershipViolationDetected() {
+        List<UUID> workoutIds = List.of(workoutId1, workoutId2);
+
+        when(blockRepository.findById(blockId)).thenReturn(Optional.of(libraryBlock));
+        // Only one workout returned — ownership violation on the second
+        when(workoutRepository.findAllByIdInAndUserId(workoutIds, userId))
+                .thenReturn(List.of(workout1));
+
+        assertThatThrownBy(() -> workoutService.bulkReplaceSection(
+                workoutIds, SectionType.MAINSET, blockId, userId))
+                .isInstanceOf(WorkoutNotFoundException.class);
+
+        // No mutations must have been applied
+        verify(workoutRepository, never()).save(any(Workout.class));
+    }
+
+    /**
+     * Verifies that {@code bulkReplaceSection} throws {@link WorkoutNotFoundException}
+     * when none of the requested IDs match the user.
+     */
+    @Test
+    void bulkReplaceSection_throwsWorkoutNotFoundException_whenNoWorkoutsFound() {
+        List<UUID> workoutIds = List.of(workoutId1, workoutId2);
+
+        when(blockRepository.findById(blockId)).thenReturn(Optional.of(libraryBlock));
+        when(workoutRepository.findAllByIdInAndUserId(workoutIds, userId))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> workoutService.bulkReplaceSection(
+                workoutIds, SectionType.MAINSET, blockId, userId))
+                .isInstanceOf(WorkoutNotFoundException.class);
+
+        verify(workoutRepository, never()).save(any(Workout.class));
+    }
+}

--- a/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
## Issue
Closes #70 — Post-MVP: Batch workout fetch for export and bulk replace

## What was done
- Added `findAllByIdInAndUserId(List<UUID> ids, UUID userId)` to `WorkoutRepository` — Spring Data derives the single-query implementation automatically
- Refactored `exportWorkouts` to use the batch method instead of a per-workout loop; verifies result count matches request count to catch ownership violations
- Refactored `bulkReplaceSection` with the same approach

## Tests added
`WorkoutServiceBatchFetchTest.java` — 7 Mockito unit tests (no Spring context):
- `exportWorkouts_usesSingleBatchQuery` — `findAllByIdInAndUserId` called once; `findById` never called
- `exportWorkouts_passesAllWorkoutsToZipBuilder`
- `exportWorkouts_throwsWorkoutNotFoundException_whenOwnershipViolationDetected`
- `exportWorkouts_throwsWorkoutNotFoundException_whenNoWorkoutsFound`
- `bulkReplaceSection_usesSingleBatchQuery`
- `bulkReplaceSection_throwsWorkoutNotFoundException_whenOwnershipViolationDetected`
- `bulkReplaceSection_throwsWorkoutNotFoundException_whenNoWorkoutsFound`

## Needs manual testing
None — backend-only refactor; no user-facing behaviour changes. All acceptance criteria covered by unit tests.

## Areas affected
**backend** — `repositories/WorkoutRepository.java`, `services/WorkoutService.java`, new `test/.../services/WorkoutServiceBatchFetchTest.java`