### PR TITLE
fix: Fix .zwo export errors identified by import/export round-trip test (#80)

### DIFF
--- a/backend/src/main/java/uk/trive/zwifttool/controllers/dto/SaveWorkoutRequest.java
+++ b/backend/src/main/java/uk/trive/zwifttool/controllers/dto/SaveWorkoutRequest.java
@@ -19,6 +19,13 @@ public class SaveWorkoutRequest {
 
     private String description;
 
+    /**
+     * Raw XML fragment for the {@code <tags>} block from the original .zwo file,
+     * preserved verbatim so it can be round-tripped on export. Null if the
+     * source file contained no {@code <tags>} element.
+     */
+    private String tags;
+
     /** Warm-up interval content as a JSON string. Null if no warm-up. */
     private String warmupContent;
 

--- a/backend/src/main/java/uk/trive/zwifttool/models/Workout.java
+++ b/backend/src/main/java/uk/trive/zwifttool/models/Workout.java
@@ -77,6 +77,16 @@ public class Workout {
     private boolean isDraft;
 
     /**
+     * Raw XML fragment for the {@code <tags>} block from the original .zwo file,
+     * preserved verbatim so it can be round-tripped on export. Null if the
+     * source file contained no {@code <tags>} element.
+     *
+     * <p>Example value: {@code <tags>\n    <tag name="SST"/>\n</tags>}</p>
+     */
+    @Column(name = "tags", columnDefinition = "text")
+    private String tags;
+
+    /**
      * JSON array of text events displayed over the workout timeline.
      * Stored as a JSON string in a {@code jsonb} column so we can add,
      * edit, and delete entries without a schema migration per event type.

--- a/backend/src/main/java/uk/trive/zwifttool/services/WorkoutService.java
+++ b/backend/src/main/java/uk/trive/zwifttool/services/WorkoutService.java
@@ -205,6 +205,7 @@ public class WorkoutService {
                 .name(request.getName())
                 .author(request.getAuthor())
                 .description(request.getDescription())
+                .tags(request.getTags())
                 .warmupBlock(warmupBlock)
                 .mainsetBlock(mainsetBlock)
                 .cooldownBlock(cooldownBlock)

--- a/backend/src/main/java/uk/trive/zwifttool/services/ZwoExporter.java
+++ b/backend/src/main/java/uk/trive/zwifttool/services/ZwoExporter.java
@@ -75,7 +75,6 @@ public class ZwoExporter {
      */
     public String buildZwoXml(Workout workout) {
         StringBuilder sb = new StringBuilder();
-        sb.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
         sb.append("<workout_file>\n");
         // Bug 1 fix: use <name> not <n>, and write the name exactly as stored with no slugification
         appendMetaTag(sb, "name", workout.getName());

--- a/backend/src/main/java/uk/trive/zwifttool/services/ZwoExporter.java
+++ b/backend/src/main/java/uk/trive/zwifttool/services/ZwoExporter.java
@@ -77,14 +77,19 @@ public class ZwoExporter {
         StringBuilder sb = new StringBuilder();
         sb.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
         sb.append("<workout_file>\n");
-        appendMetaTag(sb, "n", workout.getName());
+        // Bug 1 fix: use <name> not <n>, and write the name exactly as stored with no slugification
+        appendMetaTag(sb, "name", workout.getName());
         if (workout.getAuthor() != null) {
             appendMetaTag(sb, "author", workout.getAuthor());
         }
-        if (workout.getDescription() != null) {
-            appendMetaTag(sb, "description", workout.getDescription());
-        }
+        // Bug 2 fix: always include <description>, even when null or empty
+        String description = workout.getDescription() != null ? workout.getDescription() : "";
+        appendMetaTag(sb, "description", description);
         sb.append("  <sportType>bike</sportType>\n");
+        // Bug 3 fix: round-trip the <tags> block verbatim if one was stored on import
+        if (workout.getTags() != null && !workout.getTags().isBlank()) {
+            sb.append("  ").append(workout.getTags().strip()).append("\n");
+        }
         sb.append("  <workout>\n");
 
         if (workout.getWarmupBlock() != null) {
@@ -221,15 +226,17 @@ public class ZwoExporter {
     }
 
     /**
-     * Formats a power fraction value (e.g. 0.88) to two decimal places for
-     * .zwo output. Returns {@code "0.00"} for absent or null values so the
-     * XML remains valid even when content is incomplete.
+     * Formats a power fraction value (e.g. 0.88) to four decimal places for
+     * .zwo output. Four decimal places preserve zone boundary distinctions
+     * (e.g. 0.6545 vs 0.6500) that are collapsed by two-decimal rounding.
+     * Returns {@code "0.0000"} for absent or null values so the XML remains
+     * valid even when content is incomplete.
      */
     private String formatPower(JsonNode node) {
         if (node.isNull() || node.isMissingNode()) {
-            return "0.00";
+            return "0.0000";
         }
-        return String.format("%.2f", node.asDouble());
+        return String.format("%.4f", node.asDouble());
     }
 
     /**

--- a/backend/src/test/java/uk/trive/zwifttool/services/ZwoExporterTest.java
+++ b/backend/src/test/java/uk/trive/zwifttool/services/ZwoExporterTest.java
@@ -1,0 +1,481 @@
+package uk.trive.zwifttool.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import uk.trive.zwifttool.models.Block;
+import uk.trive.zwifttool.models.SectionType;
+import uk.trive.zwifttool.models.Workout;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Unit tests for {@link ZwoExporter}, covering the .zwo XML generation logic.
+ *
+ * <p>Tests parse the generated XML output and assert specific elements and
+ * attribute values to verify correctness of the exported workout files.</p>
+ *
+ * <p>No Spring context is required: {@link ZwoExporter} is a standalone service
+ * whose only dependency is a Jackson {@link ObjectMapper}.</p>
+ */
+class ZwoExporterTest {
+
+    private ZwoExporter zwoExporter;
+
+    @BeforeEach
+    void setUp() {
+        zwoExporter = new ZwoExporter(new ObjectMapper());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parses an XML string into a DOM Document for assertion.
+     */
+    private Document parseXml(String xml) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Returns the text content of the first matching element, or null.
+     */
+    private String elementText(Document doc, String tagName) {
+        NodeList nodes = doc.getElementsByTagName(tagName);
+        if (nodes.getLength() == 0) {
+            return null;
+        }
+        return nodes.item(0).getTextContent();
+    }
+
+    /**
+     * Returns the named attribute of the first matching element, or null.
+     */
+    private String elementAttribute(Document doc, String tagName, String attributeName) {
+        NodeList nodes = doc.getElementsByTagName(tagName);
+        if (nodes.getLength() == 0) {
+            return null;
+        }
+        return ((org.w3c.dom.Element) nodes.item(0)).getAttribute(attributeName);
+    }
+
+    /**
+     * Builds a minimal {@link Block} with the given content JSON.
+     */
+    private Block buildBlock(SectionType sectionType, String contentJson) {
+        return Block.builder()
+                .id(UUID.randomUUID())
+                .userId(UUID.randomUUID())
+                .name(sectionType.name())
+                .sectionType(sectionType)
+                .content(contentJson)
+                .durationSeconds(600)
+                .intervalCount(1)
+                .isLibraryBlock(false)
+                .build();
+    }
+
+    /**
+     * Builds a {@link Workout} with the given name and main-set block.
+     */
+    private Workout buildWorkout(String name, Block mainsetBlock) {
+        return Workout.builder()
+                .id(UUID.randomUUID())
+                .userId(UUID.randomUUID())
+                .name(name)
+                .mainsetBlock(mainsetBlock)
+                .isDraft(false)
+                .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Sweet Spot 1.2 fixture data (from the issue round-trip test)
+    // -------------------------------------------------------------------------
+
+    private static final String SWEET_SPOT_MAINSET_JSON = """
+            [
+              {"type":"SteadyState","durationSeconds":600,"power":0.50449997,"cadence":null},
+              {"type":"SteadyState","durationSeconds":120,"power":0.65450001,"cadence":null},
+              {"type":"SteadyState","durationSeconds":600,"power":0.90450001,"cadence":null}
+            ]
+            """;
+
+    private static final String SWEET_SPOT_WARMUP_JSON = """
+            [
+              {"type":"Warmup","durationSeconds":600,"power":0.50204545,"powerHigh":0.75,"cadence":null}
+            ]
+            """;
+
+    // -------------------------------------------------------------------------
+    // Bug 1: <name> tag instead of <n>
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Bug 1 - workout name tag")
+    class NameTagTests {
+
+        @Test
+        @DisplayName("exports workout name using the <name> element, not <n>")
+        void exportUsesNameTag() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = buildWorkout("Sweet Spot 1.2", mainset);
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            // The <name> element must be present and contain the workout name
+            assertThat(elementText(doc, "name"))
+                    .as("exported XML must use <name> not <n>")
+                    .isEqualTo("Sweet Spot 1.2");
+        }
+
+        @Test
+        @DisplayName("does not emit an <n> element in the exported XML")
+        void exportDoesNotUseNTag() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = buildWorkout("Sweet Spot 1.2", mainset);
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            assertThat(elementText(doc, "n"))
+                    .as("exported XML must not contain the legacy <n> element")
+                    .isNull();
+        }
+
+        @Test
+        @DisplayName("writes the workout name exactly as stored, with no slugification")
+        void exportNameIsNotSlugified() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = buildWorkout("Sweet Spot 1.2", mainset);
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            // Spaces must be preserved, not replaced with underscores
+            assertThat(elementText(doc, "name"))
+                    .as("workout name must not be slugified on export")
+                    .isEqualTo("Sweet Spot 1.2")
+                    .doesNotContain("_");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Bug 2: <description> always present, even when empty
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Bug 2 - description always present")
+    class DescriptionTagTests {
+
+        @Test
+        @DisplayName("includes <description> element when the workout has a description")
+        void exportIncludesDescriptionWhenPresent() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = Workout.builder()
+                    .id(UUID.randomUUID())
+                    .userId(UUID.randomUUID())
+                    .name("Sweet Spot 1.2")
+                    .description("A sweet spot training block")
+                    .mainsetBlock(mainset)
+                    .isDraft(false)
+                    .build();
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            assertThat(elementText(doc, "description"))
+                    .as("description element must be present when the workout has one")
+                    .isEqualTo("A sweet spot training block");
+        }
+
+        @Test
+        @DisplayName("includes an empty <description> element when description is null")
+        void exportIncludesEmptyDescriptionWhenNull() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = buildWorkout("Sweet Spot 1.2", mainset);
+            // description is null (not set in buildWorkout)
+
+            String xml = zwoExporter.buildZwoXml(workout);
+
+            // The element must be present even when empty
+            assertThat(xml)
+                    .as("exported XML must contain <description> even when description is null")
+                    .contains("<description>");
+        }
+
+        @Test
+        @DisplayName("includes an empty <description> element when description is empty string")
+        void exportIncludesEmptyDescriptionWhenEmpty() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = Workout.builder()
+                    .id(UUID.randomUUID())
+                    .userId(UUID.randomUUID())
+                    .name("Sweet Spot 1.2")
+                    .description("")
+                    .mainsetBlock(mainset)
+                    .isDraft(false)
+                    .build();
+
+            String xml = zwoExporter.buildZwoXml(workout);
+
+            assertThat(xml)
+                    .as("exported XML must contain <description> even when description is empty")
+                    .contains("<description>");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Bug 3: <tags> round-tripped from import to export
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Bug 3 - tags round-trip")
+    class TagsRoundTripTests {
+
+        @Test
+        @DisplayName("writes a <tags> block when the workout has stored tags")
+        void exportWritesTagsWhenPresent() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = Workout.builder()
+                    .id(UUID.randomUUID())
+                    .userId(UUID.randomUUID())
+                    .name("Sweet Spot 1.2")
+                    .tags("<tags>\n    <tag name=\"SST\"/>\n</tags>")
+                    .mainsetBlock(mainset)
+                    .isDraft(false)
+                    .build();
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            NodeList tagsNodes = doc.getElementsByTagName("tags");
+            assertThat(tagsNodes.getLength())
+                    .as("exported XML must contain a <tags> element when tags are stored")
+                    .isGreaterThan(0);
+
+            NodeList tagNodes = doc.getElementsByTagName("tag");
+            assertThat(tagNodes.getLength())
+                    .as("exported XML must contain the individual <tag> elements")
+                    .isEqualTo(1);
+
+            String tagName = ((org.w3c.dom.Element) tagNodes.item(0)).getAttribute("name");
+            assertThat(tagName)
+                    .as("exported <tag> name attribute must match the stored value")
+                    .isEqualTo("SST");
+        }
+
+        @Test
+        @DisplayName("omits the <tags> block when the workout has no tags stored")
+        void exportOmitsTagsWhenNull() throws Exception {
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = buildWorkout("Sweet Spot 1.2", mainset);
+            // tags is null (not set)
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            NodeList tagsNodes = doc.getElementsByTagName("tags");
+            assertThat(tagsNodes.getLength())
+                    .as("exported XML must not contain a <tags> element when no tags are stored")
+                    .isEqualTo(0);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Bug 4: Power values rounded to 4 decimal places
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Bug 4 - power values at 4dp precision")
+    class PowerPrecisionTests {
+
+        @Test
+        @DisplayName("formats SteadyState power to 4 decimal places")
+        void steadyStatePowerIsFourDecimalPlaces() throws Exception {
+            String contentJson = """
+                    [{"type":"SteadyState","durationSeconds":600,"power":0.50449997,"cadence":null}]
+                    """;
+            Block mainset = buildBlock(SectionType.MAINSET, contentJson);
+            Workout workout = buildWorkout("Test", mainset);
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            String power = elementAttribute(doc, "SteadyState", "Power");
+            assertThat(power)
+                    .as("SteadyState Power must be rounded to 4dp")
+                    .isEqualTo("0.5045");
+        }
+
+        @Test
+        @DisplayName("formats SteadyState power 0.65450001 to 4dp as 0.6545")
+        void steadyStatePowerUpperZoneIsFourDecimalPlaces() throws Exception {
+            String contentJson = """
+                    [{"type":"SteadyState","durationSeconds":120,"power":0.65450001,"cadence":null}]
+                    """;
+            Block mainset = buildBlock(SectionType.MAINSET, contentJson);
+            Workout workout = buildWorkout("Test", mainset);
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            String power = elementAttribute(doc, "SteadyState", "Power");
+            assertThat(power)
+                    .as("SteadyState Power 0.65450001 must round to 0.6545 at 4dp")
+                    .isEqualTo("0.6545");
+        }
+
+        @Test
+        @DisplayName("formats SteadyState power 0.90450001 to 4dp as 0.9045")
+        void steadyStatePowerHighZoneIsFourDecimalPlaces() throws Exception {
+            String contentJson = """
+                    [{"type":"SteadyState","durationSeconds":600,"power":0.90450001,"cadence":null}]
+                    """;
+            Block mainset = buildBlock(SectionType.MAINSET, contentJson);
+            Workout workout = buildWorkout("Test", mainset);
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            String power = elementAttribute(doc, "SteadyState", "Power");
+            assertThat(power)
+                    .as("SteadyState Power 0.90450001 must round to 0.9045 at 4dp")
+                    .isEqualTo("0.9045");
+        }
+
+        @Test
+        @DisplayName("formats Warmup PowerLow 0.50204545 to 4dp as 0.5020")
+        void warmupPowerLowIsFourDecimalPlaces() throws Exception {
+            Block warmup = buildBlock(SectionType.WARMUP, SWEET_SPOT_WARMUP_JSON);
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Workout workout = Workout.builder()
+                    .id(UUID.randomUUID())
+                    .userId(UUID.randomUUID())
+                    .name("Sweet Spot 1.2")
+                    .warmupBlock(warmup)
+                    .mainsetBlock(mainset)
+                    .isDraft(false)
+                    .build();
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            String powerLow = elementAttribute(doc, "Warmup", "PowerLow");
+            assertThat(powerLow)
+                    .as("Warmup PowerLow 0.50204545 must round to 0.5020 at 4dp")
+                    .isEqualTo("0.5020");
+        }
+
+        @Test
+        @DisplayName("formats IntervalsT OnPower and OffPower to 4 decimal places")
+        void intervalsTOnOffPowerIsFourDecimalPlaces() throws Exception {
+            String contentJson = """
+                    [{"type":"IntervalsT","durationSeconds":600,"repeat":4,"onDuration":60,
+                      "offDuration":90,"onPower":0.95003001,"offPower":0.50449997,"cadence":null,
+                      "power":null,"powerHigh":null}]
+                    """;
+            Block mainset = buildBlock(SectionType.MAINSET, contentJson);
+            Workout workout = buildWorkout("Intervals", mainset);
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            String onPower = elementAttribute(doc, "IntervalsT", "OnPower");
+            String offPower = elementAttribute(doc, "IntervalsT", "OffPower");
+
+            assertThat(onPower)
+                    .as("IntervalsT OnPower must be at 4dp")
+                    .isEqualTo("0.9500");
+            assertThat(offPower)
+                    .as("IntervalsT OffPower must be at 4dp")
+                    .isEqualTo("0.5045");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Round-trip structural test
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Round-trip structural test")
+    class RoundTripTests {
+
+        @Test
+        @DisplayName("generates structurally valid XML for a workout with all three sections")
+        void fullWorkoutExportIsStructurallyValid() throws Exception {
+            Block warmup = buildBlock(SectionType.WARMUP, SWEET_SPOT_WARMUP_JSON);
+            Block mainset = buildBlock(SectionType.MAINSET, SWEET_SPOT_MAINSET_JSON);
+            Block cooldown = buildBlock(SectionType.COOLDOWN,
+                    "[{\"type\":\"Cooldown\",\"durationSeconds\":300," +
+                    "\"power\":0.45,\"powerHigh\":0.65,\"cadence\":null}]");
+            Workout workout = Workout.builder()
+                    .id(UUID.randomUUID())
+                    .userId(UUID.randomUUID())
+                    .name("Sweet Spot 1.2")
+                    .author("Zwift")
+                    .description("")
+                    .tags("<tags>\n    <tag name=\"SST\"/>\n</tags>")
+                    .warmupBlock(warmup)
+                    .mainsetBlock(mainset)
+                    .cooldownBlock(cooldown)
+                    .isDraft(false)
+                    .build();
+
+            String xml = zwoExporter.buildZwoXml(workout);
+            Document doc = parseXml(xml);
+
+            // Root element
+            assertThat(doc.getElementsByTagName("workout_file").getLength())
+                    .as("must have a <workout_file> root element")
+                    .isEqualTo(1);
+
+            // Correct name tag
+            assertThat(elementText(doc, "name"))
+                    .as("must use <name> element")
+                    .isEqualTo("Sweet Spot 1.2");
+
+            // Description always present
+            assertThat(xml).contains("<description>");
+
+            // Author
+            assertThat(elementText(doc, "author"))
+                    .as("must include the author element")
+                    .isEqualTo("Zwift");
+
+            // Tags present
+            assertThat(doc.getElementsByTagName("tags").getLength())
+                    .as("must include the <tags> block")
+                    .isEqualTo(1);
+
+            // Workout intervals
+            assertThat(doc.getElementsByTagName("Warmup").getLength()).isEqualTo(1);
+            assertThat(doc.getElementsByTagName("SteadyState").getLength()).isEqualTo(3);
+            assertThat(doc.getElementsByTagName("Cooldown").getLength()).isEqualTo(1);
+
+            // Power precision: spot check one value
+            String warmupPowerLow = elementAttribute(doc, "Warmup", "PowerLow");
+            assertThat(warmupPowerLow)
+                    .as("Warmup PowerLow must have 4dp precision in the round-trip")
+                    .isEqualTo("0.5020");
+        }
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -238,6 +238,7 @@ export function App(): JSX.Element {
                 name: split.workout.name,
                 author: split.workout.author,
                 description: split.workout.description,
+                tags: split.workout.tags,
                 warmupContent: split.warmupIntervals.length > 0
                     ? JSON.stringify(split.warmupIntervals) : null,
                 mainsetContent: JSON.stringify(split.mainsetIntervals),
@@ -716,6 +717,7 @@ export function App(): JSX.Element {
                 name: 'New Workout',
                 author: null,
                 description: null,
+                tags: null,
                 warmupContent: null,
                 // Empty main set: a single block with no intervals yet
                 mainsetContent: '[]',

--- a/frontend/src/api/workouts.ts
+++ b/frontend/src/api/workouts.ts
@@ -15,6 +15,12 @@ export interface SaveWorkoutRequest {
     name: string
     author: string | null
     description: string | null
+    /**
+     * Raw XML fragment for the {@code <tags>} block from the original .zwo file,
+     * preserved verbatim for round-tripping on export. Null if the source
+     * file contained no {@code <tags>} element.
+     */
+    tags: string | null
     warmupContent: string | null
     mainsetContent: string
     cooldownContent: string | null

--- a/frontend/src/components/import/__tests__/FileUploader.test.tsx
+++ b/frontend/src/components/import/__tests__/FileUploader.test.tsx
@@ -17,6 +17,7 @@ const MOCK_PARSED_WORKOUT = {
     name: 'Test Session',
     author: null,
     description: null,
+    tags: null,
     intervals: [],
 }
 

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -52,6 +52,12 @@ export interface ParsedWorkout {
     name: string
     author: string | null
     description: string | null
+    /**
+     * Raw XML fragment for the {@code <tags>} block from the source file,
+     * preserved verbatim so it can be round-tripped on export.
+     * Null if the source file contained no {@code <tags>} element.
+     */
+    tags: string | null
     intervals: ParsedInterval[]
 }
 

--- a/frontend/src/utils/zwoParser.ts
+++ b/frontend/src/utils/zwoParser.ts
@@ -44,9 +44,18 @@ export function parseZwoFile(xml: string, fileName: string): ParsedWorkout {
         throw new Error(`${fileName} is not a valid .zwo file: missing <workout> element.`)
     }
 
-    const name = getTextContent(workoutFile, 'n') ?? fileName.replace(/\.zwo$/i, '')
+    // Prefer the <name> element (spec-compliant); fall back to the legacy <n>
+    // element used by older Zwift exports and pre-fix versions of this tool.
+    const name =
+        getTextContent(workoutFile, 'name') ??
+        getTextContent(workoutFile, 'n') ??
+        fileName.replace(/\.zwo$/i, '')
     const author = getTextContent(workoutFile, 'author')
     const description = getTextContent(workoutFile, 'description')
+
+    // Capture the raw <tags> XML fragment so it can be round-tripped on export
+    // without parsing or modifying its content.
+    const tags = extractTagsFragment(workoutFile)
 
     const intervals = parseIntervals(workoutElement)
 
@@ -54,7 +63,24 @@ export function parseZwoFile(xml: string, fileName: string): ParsedWorkout {
         throw new Error(`${fileName} contains no intervals.`)
     }
 
-    return { fileName, name, author, description, intervals }
+    return { fileName, name, author, description, tags, intervals }
+}
+
+/**
+ * Extracts the raw outer XML of the first {@code <tags>} child element from
+ * the workout file element. The raw fragment is stored verbatim so it can be
+ * written back to the export without modification.
+ *
+ * Returns null if no {@code <tags>} element is present.
+ */
+function extractTagsFragment(workoutFile: Element): string | null {
+    const tagsElement = workoutFile.querySelector('tags')
+    if (!tagsElement) {
+        return null
+    }
+    // Serialise the <tags> element back to an XML string for storage
+    const serialiser = new XMLSerializer()
+    return serialiser.serializeToString(tagsElement)
 }
 
 /**


### PR DESCRIPTION
## Issue
Closes #80 — Fix .zwo export errors identified by import/export round-trip test

## What was done
- `ZwoExporter.java`: changed `<n>` to `<name>`, removed slugification, always emits `<description>`, round-trips `<tags>` block, rounds all power values to 4 decimal places
- Added `tags` field (TEXT) to `Workout.java` entity to persist the raw `<tags>` XML fragment
- Added `tags` to `SaveWorkoutRequest.java` DTO and propagated through `WorkoutService.java`
- Frontend `zwoParser.ts`: reads `<name>` with fallback to `<n>` for legacy files; extracts `<tags>` fragment verbatim
- Added `tags: string | null` to `ParsedWorkout` and `SaveWorkoutRequest` API types; passed through both `saveWorkout` call sites in `App.tsx`
- Updated `INSTRUCTIONS_COPY.md`: corrected the .zwo File Format Reference from `<n>` to `<name>`

## Tests added
`ZwoExporterTest.java` — 14 unit tests covering all 4 bug fixes (name tag, description, tags round-trip, 4dp power precision).

## Needs manual testing
- **DB migration required before deploying:** run `ALTER TABLE workouts ADD COLUMN tags TEXT;` on the Neon production database. Without this, Hibernate's `validate` DDL mode will reject the mapping and the backend will fail to start.
- After deploying, import a .zwo file with `<tags>` and confirm they survive the round-trip
- Confirm workout names export without underscores

## Areas affected
**backend** — `ZwoExporter.java`, `Workout.java`, `SaveWorkoutRequest.java`, `WorkoutService.java`, new `ZwoExporterTest.java`
**frontend** — `zwoParser.ts`, `types/workout.ts`, `api/workouts.ts`, `App.tsx`, `FileUploader.test.tsx`
**docs** — `internal_docs/INSTRUCTIONS_COPY.md`