### PR TITLE
fix: prompt to rename, replace, or skip on duplicate workout name (#84)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { SignUpModal } from './components/auth/SignUpModal.tsx'
 import { FileUploader } from './components/import/FileUploader.tsx'
 import { IntervalList } from './components/import/IntervalList.tsx'
 import { SectionSplitter, type SectionSplit } from './components/import/SectionSplitter.tsx'
+import { DuplicateNameModal } from './components/import/DuplicateNameModal.tsx'
 import { useAuth } from './hooks/useAuth.ts'
 import { useWorkouts } from './hooks/useWorkouts.ts'
 import { useWorkout } from './hooks/useWorkout.ts'
@@ -101,6 +102,8 @@ export function App(): JSX.Element {
     const [bulkReplaceError, setBulkReplaceError] = useState<string | null>(null)
     const [isExporting, setIsExporting] = useState(false)
     const [exportError, setExportError] = useState<string | null>(null)
+    const [pendingClashes, setPendingClashes] = useState<Array<{ incoming: ParsedWorkout; existingId: string }>>([])
+    const currentClash = pendingClashes[0] ?? null
 
     // The workout driving the editor canvas. In authenticated mode this is the
     // backend-fetched selected workout; in guest mode it is the locally-held
@@ -169,13 +172,70 @@ export function App(): JSX.Element {
     }
 
     function handleFilesParsed(workouts: ParsedWorkout[]): void {
-        setParsedWorkouts(workouts)
         setSaveSuccess(null)
         setSaveError(null)
-        // Auto-start splitting if only one file was uploaded
-        if (workouts.length === 1) {
-            setSplittingWorkout(workouts[0])
+
+        if (!isAuthenticated) {
+            // Guest mode: no saved workouts to clash with
+            setParsedWorkouts(workouts)
+            if (workouts.length === 1) setSplittingWorkout(workouts[0])
+            return
         }
+
+        const clashes: Array<{ incoming: ParsedWorkout; existingId: string }> = []
+        const nonClashing: ParsedWorkout[] = []
+
+        for (const workout of workouts) {
+            const existing = savedWorkouts.find((w) => w.name === workout.name)
+            if (existing) {
+                clashes.push({ incoming: workout, existingId: existing.id })
+            } else {
+                nonClashing.push(workout)
+            }
+        }
+
+        // Add non-clashing workouts to the import queue immediately
+        setParsedWorkouts((prev) => [...prev, ...nonClashing])
+        if (clashes.length === 0 && nonClashing.length === 1) {
+            setSplittingWorkout(nonClashing[0])
+        }
+
+        if (clashes.length > 0) {
+            setPendingClashes(clashes)
+        }
+    }
+
+    function resolveClash(resolvedWorkout: ParsedWorkout | null): void {
+        setPendingClashes((prev) => {
+            const remaining = prev.slice(1)
+            // When the last clash is resolved, auto-start split if it produced one workout
+            if (remaining.length === 0 && resolvedWorkout !== null) {
+                setParsedWorkouts((current) => {
+                    const updated = [...current, resolvedWorkout]
+                    if (updated.length === 1) setSplittingWorkout(updated[0])
+                    return updated
+                })
+            } else if (resolvedWorkout !== null) {
+                setParsedWorkouts((current) => [...current, resolvedWorkout])
+            }
+            return remaining
+        })
+    }
+
+    function handleClashRename(newName: string): void {
+        if (currentClash === null) return
+        resolveClash({ ...currentClash.incoming, name: newName })
+    }
+
+    async function handleClashReplace(): Promise<void> {
+        if (currentClash === null) return
+        await deleteWorkout(currentClash.existingId)
+        await reloadWorkouts()
+        resolveClash(currentClash.incoming)
+    }
+
+    function handleClashCancel(): void {
+        resolveClash(null)
     }
 
     function handleStartSplit(workout: ParsedWorkout): void {
@@ -1338,6 +1398,14 @@ export function App(): JSX.Element {
             )}
 
             <AppFooter />
+
+            <DuplicateNameModal
+                isOpen={currentClash !== null}
+                incomingName={currentClash?.incoming.name ?? ''}
+                onRename={handleClashRename}
+                onReplace={handleClashReplace}
+                onCancel={handleClashCancel}
+            />
 
             <SaveToLibraryModal
                 isOpen={saveToLibrarySection !== null}

--- a/frontend/src/components/import/DuplicateNameModal.tsx
+++ b/frontend/src/components/import/DuplicateNameModal.tsx
@@ -1,0 +1,146 @@
+import { useState, type JSX } from 'react'
+import { Modal } from '../ui/Modal'
+
+interface Props {
+    isOpen: boolean
+    /** The name of the incoming workout that clashes with an existing saved workout. */
+    incomingName: string
+    /** Called when the user chooses to rename — receives the trimmed new name. */
+    onRename: (newName: string) => void
+    /** Called when the user chooses to replace the existing workout. Parent is responsible for the delete API call. */
+    onReplace: () => Promise<void>
+    /** Called when the user chooses to skip the incoming workout. */
+    onCancel: () => void
+}
+
+/**
+ * Modal shown when an uploaded .zwo file's name matches an existing saved workout.
+ * Offers three resolutions: rename the incoming workout, replace the existing one, or skip.
+ */
+export function DuplicateNameModal({
+    isOpen,
+    incomingName,
+    onRename,
+    onReplace,
+    onCancel,
+}: Props): JSX.Element | null {
+    const [newName, setNewName] = useState('')
+    const [isReplacing, setIsReplacing] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    function handleClose(): void {
+        setNewName('')
+        setError(null)
+        onCancel()
+    }
+
+    function handleRename(): void {
+        const trimmed = newName.trim()
+        if (trimmed.length === 0) return
+        setNewName('')
+        setError(null)
+        onRename(trimmed)
+    }
+
+    async function handleReplace(): Promise<void> {
+        setIsReplacing(true)
+        setError(null)
+        try {
+            await onReplace()
+            setNewName('')
+        } catch {
+            setError('Failed to replace the existing workout. Please try again.')
+        } finally {
+            setIsReplacing(false)
+        }
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={handleClose} title="Workout name already in use">
+            <div className="flex flex-col gap-4">
+                <p className="text-sm text-zinc-300">
+                    A workout called{' '}
+                    <span className="font-medium text-white">&ldquo;{incomingName}&rdquo;</span>{' '}
+                    is already saved to your account. Choose how to continue:
+                </p>
+
+                <div className="flex flex-col gap-2">
+                    <label className="text-sm text-zinc-300" htmlFor="duplicate-new-name">
+                        Rename incoming workout
+                    </label>
+                    <div className="flex gap-2">
+                        <input
+                            id="duplicate-new-name"
+                            type="text"
+                            value={newName}
+                            onChange={(e) => setNewName(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === 'Enter') handleRename() }}
+                            placeholder="Enter a new name..."
+                            autoFocus
+                            className={`
+                                flex-1 px-3 py-2
+                                bg-zinc-700 text-white text-sm
+                                rounded-md border border-zinc-600
+                                placeholder:text-zinc-500
+                                focus:outline-none focus:border-brand-500
+                            `}
+                        />
+                        <button
+                            type="button"
+                            onClick={handleRename}
+                            disabled={newName.trim().length === 0}
+                            className={`
+                                px-4 py-2
+                                bg-brand-600 text-white text-sm font-medium
+                                rounded-md
+                                hover:bg-brand-500 transition-colors
+                                focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:ring-offset-zinc-800
+                                disabled:opacity-50 disabled:cursor-not-allowed
+                            `}
+                        >
+                            Rename
+                        </button>
+                    </div>
+                </div>
+
+                <div className="border-t border-zinc-700 pt-4 flex flex-col gap-3">
+                    <button
+                        type="button"
+                        onClick={() => void handleReplace()}
+                        disabled={isReplacing}
+                        className={`
+                            w-full px-4 py-2
+                            bg-zinc-700 text-white text-sm font-medium
+                            rounded-md
+                            hover:bg-zinc-600 transition-colors
+                            focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:ring-offset-zinc-800
+                            disabled:opacity-50 disabled:cursor-not-allowed
+                        `}
+                    >
+                        {isReplacing ? 'Replacing...' : 'Replace existing workout'}
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={handleClose}
+                        disabled={isReplacing}
+                        className={`
+                            w-full px-4 py-2
+                            bg-transparent text-zinc-400 text-sm
+                            rounded-md
+                            hover:text-white transition-colors
+                            focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:ring-offset-zinc-800
+                            disabled:opacity-50 disabled:cursor-not-allowed
+                        `}
+                    >
+                        Skip this file
+                    </button>
+                </div>
+
+                {error !== null && (
+                    <p className="text-sm text-red-400">{error}</p>
+                )}
+            </div>
+        </Modal>
+    )
+}

--- a/frontend/src/components/import/__tests__/DuplicateNameModal.test.tsx
+++ b/frontend/src/components/import/__tests__/DuplicateNameModal.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DuplicateNameModal } from '../DuplicateNameModal'
+
+describe('DuplicateNameModal', () => {
+    const defaultProps = {
+        isOpen: true,
+        incomingName: 'Morning Ride',
+        onRename: vi.fn(),
+        onReplace: vi.fn().mockResolvedValue(undefined),
+        onCancel: vi.fn(),
+    }
+
+    it('renders the clashing workout name in the modal body', () => {
+        render(<DuplicateNameModal {...defaultProps} />)
+        expect(screen.getByText(/Morning Ride/)).toBeInTheDocument()
+    })
+
+    it('renders the Rename, Replace, and Skip buttons', () => {
+        render(<DuplicateNameModal {...defaultProps} />)
+        expect(screen.getByRole('button', { name: /rename/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /replace existing/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /skip/i })).toBeInTheDocument()
+    })
+
+    it('calls onCancel when Skip is clicked', async () => {
+        const user = userEvent.setup()
+        const onCancel = vi.fn()
+        render(<DuplicateNameModal {...defaultProps} onCancel={onCancel} />)
+
+        await user.click(screen.getByRole('button', { name: /skip/i }))
+
+        expect(onCancel).toHaveBeenCalledOnce()
+    })
+
+    it('calls onReplace when Replace existing is clicked', async () => {
+        const user = userEvent.setup()
+        const onReplace = vi.fn().mockResolvedValue(undefined)
+        render(<DuplicateNameModal {...defaultProps} onReplace={onReplace} />)
+
+        await user.click(screen.getByRole('button', { name: /replace existing/i }))
+
+        await waitFor(() => {
+            expect(onReplace).toHaveBeenCalledOnce()
+        })
+    })
+
+    it('disables Rename when the name input is empty', () => {
+        render(<DuplicateNameModal {...defaultProps} />)
+        expect(screen.getByRole('button', { name: /rename/i })).toBeDisabled()
+    })
+
+    it('enables Rename once a non-empty name is typed', async () => {
+        const user = userEvent.setup()
+        render(<DuplicateNameModal {...defaultProps} />)
+
+        await user.type(screen.getByRole('textbox'), 'Evening Ride')
+
+        expect(screen.getByRole('button', { name: /rename/i })).not.toBeDisabled()
+    })
+
+    it('calls onRename with the trimmed new name when Rename is confirmed', async () => {
+        const user = userEvent.setup()
+        const onRename = vi.fn()
+        render(<DuplicateNameModal {...defaultProps} onRename={onRename} />)
+
+        await user.type(screen.getByRole('textbox'), '  Evening Ride  ')
+        await user.click(screen.getByRole('button', { name: /rename/i }))
+
+        expect(onRename).toHaveBeenCalledWith('Evening Ride')
+    })
+
+    it('does not render when isOpen is false', () => {
+        render(<DuplicateNameModal {...defaultProps} isOpen={false} />)
+        expect(screen.queryByText(/Morning Ride/)).not.toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
## Issue
Closes #84 — Duplicate workout name clash on import

## What was done
- Added `DuplicateNameModal` component (`src/components/import/DuplicateNameModal.tsx`) with three resolution paths: rename (text input), replace existing, or skip
- Modified `handleFilesParsed` in `App.tsx` to detect name clashes against the authenticated user's saved workout list before proceeding to section splitting
- Non-clashing files proceed immediately; clashing files queue in `pendingClashes` and are shown one at a time
- Added 8 unit tests covering all interaction paths

## Tests added
`src/components/import/__tests__/DuplicateNameModal.test.tsx` — 8 tests: renders incoming name, shows all three action buttons, Skip calls onCancel, Replace calls onReplace, Rename button disabled when input is empty, enabled when text is entered, calls onRename with trimmed value, modal hidden when isOpen is false.

## Needs manual testing
- Import a `.zwo` file whose name matches an existing workout and confirm the modal appears
- Choose Rename: enter a new name and confirm the workout imports under the new name
- Choose Replace: confirm the existing workout is overwritten
- Choose Skip: confirm the file is not imported and the next clash (if any) is shown
- Import multiple files where more than one clashes to confirm the queue processes them in order

## Areas affected
**Frontend** — import flow (`App.tsx`, new `DuplicateNameModal` component)