### PR TITLE
fix: preserve FTP% decimal precision on .zwo import (#106)

### DIFF
--- a/frontend/src/components/import/IntervalList.tsx
+++ b/frontend/src/components/import/IntervalList.tsx
@@ -107,20 +107,20 @@ function formatPower(interval: ParsedInterval): string {
     }
 
     if (interval.type === 'IntervalsT') {
-        const on = interval.onPower !== null ? `${Math.round(interval.onPower * 100)}%` : '–'
-        const off = interval.offPower !== null ? `${Math.round(interval.offPower * 100)}%` : '–'
+        const on = interval.onPower !== null ? `${Number((interval.onPower * 100).toFixed(1))}%` : '–'
+        const off = interval.offPower !== null ? `${Number((interval.offPower * 100).toFixed(1))}%` : '–'
         const repeats = interval.repeat ?? 0
         return `${repeats}× ${on} / ${off}`
     }
 
     // Ramp, Warmup, Cooldown with PowerLow and PowerHigh
     if (interval.power !== null && interval.powerHigh !== null) {
-        return `${Math.round(interval.power * 100)}% → ${Math.round(interval.powerHigh * 100)}%`
+        return `${Number((interval.power * 100).toFixed(1))}% → ${Number((interval.powerHigh * 100).toFixed(1))}%`
     }
 
     // SteadyState or single power value
     if (interval.power !== null) {
-        return `${Math.round(interval.power * 100)}%`
+        return `${Number((interval.power * 100).toFixed(1))}%`
     }
 
     return '–'

--- a/frontend/src/components/workout/IntervalEditor.tsx
+++ b/frontend/src/components/workout/IntervalEditor.tsx
@@ -292,9 +292,9 @@ interface FtpFieldProps {
     onChange: (nextFraction: number) => void
 }
 
-/** %FTP input that round-trips between integer percent and 0..1 fraction. */
+/** %FTP input that round-trips between decimal percent and 0..1 fraction. Preserves one decimal place of precision. */
 function FtpField({ label, powerFraction, onChange }: FtpFieldProps): JSX.Element {
-    const percent = powerFraction !== null ? Math.round(powerFraction * 100) : 0
+    const percent = powerFraction !== null ? Number((powerFraction * 100).toFixed(1)) : 0
     return (
         <NumberField
             label={label}

--- a/frontend/src/components/workout/WorkoutIntervalTable.tsx
+++ b/frontend/src/components/workout/WorkoutIntervalTable.tsx
@@ -127,37 +127,37 @@ interface IntervalRowProps {
  */
 function IntervalRow({ interval, deleteDisabled, onUpdate, onDelete }: IntervalRowProps): JSX.Element {
     const [powerStr, setPowerStr] = useState(
-        interval.power !== null ? String(Math.round(interval.power * 100)) : '',
+        interval.power !== null ? String(Number((interval.power * 100).toFixed(1))) : '',
     )
     const [powerHighStr, setPowerHighStr] = useState(
-        interval.powerHigh !== null ? String(Math.round(interval.powerHigh * 100)) : '',
+        interval.powerHigh !== null ? String(Number((interval.powerHigh * 100).toFixed(1))) : '',
     )
     const [durationStr, setDurationStr] = useState(String(interval.durationSeconds))
     const [repeatStr, setRepeatStr] = useState(String(interval.repeat ?? 1))
     const [onDurationStr, setOnDurationStr] = useState(String(interval.onDuration ?? 0))
     const [offDurationStr, setOffDurationStr] = useState(String(interval.offDuration ?? 0))
     const [onPowerStr, setOnPowerStr] = useState(
-        interval.onPower !== null ? String(Math.round(interval.onPower * 100)) : '',
+        interval.onPower !== null ? String(Number((interval.onPower * 100).toFixed(1))) : '',
     )
     const [offPowerStr, setOffPowerStr] = useState(
-        interval.offPower !== null ? String(Math.round(interval.offPower * 100)) : '',
+        interval.offPower !== null ? String(Number((interval.offPower * 100).toFixed(1))) : '',
     )
 
     function commitPower(): void {
-        const n = parseInt(powerStr, 10)
+        const n = parseFloat(powerStr)
         if (!isNaN(n) && n >= 0) {
             onUpdate({ ...interval, power: n / 100 })
         } else {
-            setPowerStr(interval.power !== null ? String(Math.round(interval.power * 100)) : '')
+            setPowerStr(interval.power !== null ? String(Number((interval.power * 100).toFixed(1))) : '')
         }
     }
 
     function commitPowerHigh(): void {
-        const n = parseInt(powerHighStr, 10)
+        const n = parseFloat(powerHighStr)
         if (!isNaN(n) && n >= 0) {
             onUpdate({ ...interval, powerHigh: n / 100 })
         } else {
-            setPowerHighStr(interval.powerHigh !== null ? String(Math.round(interval.powerHigh * 100)) : '')
+            setPowerHighStr(interval.powerHigh !== null ? String(Number((interval.powerHigh * 100).toFixed(1))) : '')
         }
     }
 
@@ -207,20 +207,20 @@ function IntervalRow({ interval, deleteDisabled, onUpdate, onDelete }: IntervalR
     }
 
     function commitOnPower(): void {
-        const n = parseInt(onPowerStr, 10)
+        const n = parseFloat(onPowerStr)
         if (!isNaN(n) && n >= 0) {
             onUpdate({ ...interval, onPower: n / 100 })
         } else {
-            setOnPowerStr(interval.onPower !== null ? String(Math.round(interval.onPower * 100)) : '')
+            setOnPowerStr(interval.onPower !== null ? String(Number((interval.onPower * 100).toFixed(1))) : '')
         }
     }
 
     function commitOffPower(): void {
-        const n = parseInt(offPowerStr, 10)
+        const n = parseFloat(offPowerStr)
         if (!isNaN(n) && n >= 0) {
             onUpdate({ ...interval, offPower: n / 100 })
         } else {
-            setOffPowerStr(interval.offPower !== null ? String(Math.round(interval.offPower * 100)) : '')
+            setOffPowerStr(interval.offPower !== null ? String(Number((interval.offPower * 100).toFixed(1))) : '')
         }
     }
 

--- a/frontend/src/utils/__tests__/zwoParser.test.ts
+++ b/frontend/src/utils/__tests__/zwoParser.test.ts
@@ -45,6 +45,28 @@ describe('parseZwoFile', () => {
             expect(interval.power).toBeCloseTo(0.88)
         })
 
+        it('preserves sub-integer FTP% precision on import', () => {
+            const xml = `<workout_file>
+  <n>Precision Test</n>
+  <workout>
+    <SteadyState Duration="300" Power="0.876"/>
+    <IntervalsT Repeat="3" OnDuration="60" OffDuration="30" OnPower="1.134" OffPower="0.567"/>
+    <Warmup Duration="300" PowerLow="0.401" PowerHigh="0.749"/>
+  </workout>
+</workout_file>`
+            const result = parseZwoFile(xml, 'precision.zwo')
+            const steady = result.intervals[0]
+            const intervals = result.intervals[1]
+            const warmup = result.intervals[2]
+
+            // Parser must not round — values should match the XML exactly
+            expect(steady.power).toBe(0.876)
+            expect(intervals.onPower).toBe(1.134)
+            expect(intervals.offPower).toBe(0.567)
+            expect(warmup.power).toBe(0.401)
+            expect(warmup.powerHigh).toBe(0.749)
+        })
+
         it('parses all six supported interval types', () => {
             const result = parseZwoFile(ALL_INTERVAL_TYPES_ZWO, 'all-types.zwo')
             expect(result.intervals).toHaveLength(6)


### PR DESCRIPTION
## Issue
Closes #106 — FTP% values rounded to integers on import

## What was done
- Fixed `WorkoutIntervalTable.tsx`: replaced `Math.round(power * 100)` with `Number((power * 100).toFixed(1))` for all four power field initialisations, and replaced `parseInt` with `parseFloat` in all four commit functions so sub-integer FTP% values survive editing
- Fixed `IntervalEditor.tsx`: changed the `FtpField` display from `Math.round(powerFraction * 100)` to `Number((powerFraction * 100).toFixed(1))`
- Fixed `IntervalList.tsx` (import preview): changed four `Math.round(power * 100)` display calls to `Number((power * 100).toFixed(1))`
- Added a precision preservation test to `zwoParser.test.ts`

## Tests added
New test case in `src/utils/__tests__/zwoParser.test.ts`: `'preserves sub-integer FTP% precision on import'` — verifies that `SteadyState`, `IntervalsT`, and `Warmup` elements with values like `0.876`, `1.134`, `0.567`, `0.401`, `0.749` are parsed without rounding.

## Needs manual testing
- Import a `.zwo` file containing a `SteadyState` or `Warmup` with a non-integer power value (e.g. 87.6% FTP) and confirm the interval table shows `87.6` rather than `88`
- Edit that value in the interval table, confirm it saves as `87.6` and not rounded

## Areas affected
**Frontend** — interval display and editing (`WorkoutIntervalTable.tsx`, `IntervalEditor.tsx`, `IntervalList.tsx`, `zwoParser.test.ts`)