### PR TITLE
feat: implement normalised power and intensity factor with FTP input (#107)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,6 +101,8 @@ export function App(): JSX.Element {
     const [bulkReplaceError, setBulkReplaceError] = useState<string | null>(null)
     const [isExporting, setIsExporting] = useState(false)
     const [exportError, setExportError] = useState<string | null>(null)
+    // FTP stored at session level so it persists when the user switches between workouts
+    const [ftpWatts, setFtpWatts] = useState<number | null>(null)
 
     // The workout driving the editor canvas. In authenticated mode this is the
     // backend-fetched selected workout; in guest mode it is the locally-held
@@ -1094,6 +1096,8 @@ export function App(): JSX.Element {
                                 isSaving={isSavingMetadata}
                                 onExport={() => void handleExportWorkout()}
                                 isExporting={isExporting}
+                                ftpWatts={ftpWatts}
+                                onFtpChange={setFtpWatts}
                             />
                         )}
 
@@ -1137,6 +1141,7 @@ export function App(): JSX.Element {
                                 )
                                 void handleSaveTextEvents(updated)
                             }}
+                            ftpWatts={ftpWatts}
                         />
 
                         {activeWorkout !== null && (

--- a/frontend/src/components/workout/WorkoutCanvas.tsx
+++ b/frontend/src/components/workout/WorkoutCanvas.tsx
@@ -6,6 +6,9 @@ import {
     formatDuration,
     normalisedPowerBeta,
     totalDurationSeconds,
+    expandBarsToWatts,
+    calculateNormalisedPower,
+    calculateIntensityFactor,
 } from '../../utils/workoutStats'
 import type { ZonePresetView } from '../../api/zonePresets'
 import { IntervalPalette, PaletteItemShape } from './IntervalPalette'
@@ -119,6 +122,8 @@ interface Props {
      * The parent is responsible for persisting the updated text event list.
      */
     onMoveTextEvent?: (eventIndex: number, newOffsetSeconds: number) => void
+    /** The user's FTP in watts. When provided, NP and IF are calculated and displayed. */
+    ftpWatts?: number | null
 }
 
 /** Default Y-axis upper bound in percent FTP. Expands if any bar exceeds it. */
@@ -298,6 +303,7 @@ export function WorkoutCanvas({
     onUpdateInterval,
     onDeleteInterval,
     onMoveTextEvent,
+    ftpWatts = null,
 }: Props): JSX.Element {
     if (isLoading) {
         return (
@@ -331,6 +337,14 @@ export function WorkoutCanvas({
     const np = normalisedPowerBeta(allBars)
     const yMax = computeYMax(allBars)
 
+    // NP and IF are only calculated when the user has entered their FTP
+    const npWatts = ftpWatts !== null
+        ? calculateNormalisedPower(expandBarsToWatts(allBars, ftpWatts))
+        : null
+    const intensityFactor = npWatts !== null && ftpWatts !== null
+        ? calculateIntensityFactor(npWatts, ftpWatts)
+        : null
+
     return (
         <div className="flex flex-col w-full gap-3">
             {workout.isDraft && (
@@ -363,7 +377,12 @@ export function WorkoutCanvas({
                 onMoveTextEvent={onMoveTextEvent}
             />
 
-            <WorkoutFooter totalSeconds={total} normalisedPower={np} />
+            <WorkoutFooter
+                totalSeconds={total}
+                normalisedPower={np}
+                npWatts={npWatts}
+                intensityFactor={intensityFactor}
+            />
         </div>
     )
 }
@@ -2579,13 +2598,18 @@ function UndoButton({ sectionType, disabled, onClick }: UndoButtonProps): JSX.El
 interface WorkoutFooterProps {
     totalSeconds: number
     normalisedPower: number
+    /** Normalised Power in watts, only present when the user has entered their FTP. */
+    npWatts: number | null
+    /** Intensity Factor, only present when the user has entered their FTP. */
+    intensityFactor: number | null
 }
 
 /**
- * Renders the stats footer beneath the chart: total duration, normalised
- * power (beta), and a TSS placeholder labelled "Coming soon".
+ * Renders the stats footer beneath the chart: total duration, NP, and IF.
+ * NP and IF require FTP to be set; without it the beta approximation is shown
+ * and a prompt to enter FTP is displayed in place of the IF stat.
  */
-function WorkoutFooter({ totalSeconds, normalisedPower }: WorkoutFooterProps): JSX.Element {
+function WorkoutFooter({ totalSeconds, normalisedPower, npWatts, intensityFactor }: WorkoutFooterProps): JSX.Element {
     return (
         <div className="flex flex-wrap items-center gap-6 px-1 text-sm">
             <div className="flex items-baseline gap-2">
@@ -2593,15 +2617,29 @@ function WorkoutFooter({ totalSeconds, normalisedPower }: WorkoutFooterProps): J
                 <span className="text-white font-medium">{formatDuration(totalSeconds)}</span>
             </div>
 
-            <div className="flex items-baseline gap-2">
-                <span className="text-zinc-400">NP (beta)</span>
-                <span className="text-white font-medium">{normalisedPower}% FTP</span>
-            </div>
+            {npWatts !== null ? (
+                <div className="flex items-baseline gap-2">
+                    <span className="text-zinc-400">NP</span>
+                    <span className="text-white font-medium">{npWatts}W</span>
+                </div>
+            ) : (
+                <div className="flex items-baseline gap-2">
+                    <span className="text-zinc-400">NP (beta)</span>
+                    <span className="text-white font-medium">{normalisedPower}% FTP</span>
+                </div>
+            )}
 
-            <div className="flex items-baseline gap-2">
-                <span className="text-zinc-400">TSS</span>
-                <span className="text-zinc-500 italic">Coming soon</span>
-            </div>
+            {intensityFactor !== null ? (
+                <div className="flex items-baseline gap-2">
+                    <span className="text-zinc-400">IF</span>
+                    <span className="text-white font-medium">{intensityFactor}</span>
+                </div>
+            ) : (
+                <div className="flex items-baseline gap-2">
+                    <span className="text-zinc-400">IF</span>
+                    <span className="text-zinc-500 text-xs">Enter FTP above</span>
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/components/workout/WorkoutMetadataEditor.tsx
+++ b/frontend/src/components/workout/WorkoutMetadataEditor.tsx
@@ -15,6 +15,10 @@ interface Props {
     onExport?: () => void
     /** True while an export request is in flight. */
     isExporting?: boolean
+    /** The user's current FTP in watts, stored in session state by the parent. */
+    ftpWatts: number | null
+    /** Called when the user changes the FTP input. Null means the field was cleared. */
+    onFtpChange: (watts: number | null) => void
 }
 
 /**
@@ -30,10 +34,11 @@ interface Props {
  * is expected to pass {@code key={workout.id}} so that switching workouts
  * remounts the editor and picks up fresh values without an effect.</p>
  */
-export function WorkoutMetadataEditor({ workout, onSave, isSaving, onExport, isExporting = false }: Props): JSX.Element {
+export function WorkoutMetadataEditor({ workout, onSave, isSaving, onExport, isExporting = false, ftpWatts, onFtpChange }: Props): JSX.Element {
     const [name, setName] = useState<string>(workout.name)
     const [author, setAuthor] = useState<string>(workout.author ?? '')
     const [description, setDescription] = useState<string>(workout.description ?? '')
+    const [ftpStr, setFtpStr] = useState<string>(ftpWatts !== null ? String(ftpWatts) : '')
 
     function handleNameBlur(): void {
         const trimmed = name.trim()
@@ -62,6 +67,20 @@ export function WorkoutMetadataEditor({ workout, onSave, isSaving, onExport, isE
             author: next,
             description: workout.description,
         })
+    }
+
+    function handleFtpBlur(): void {
+        const trimmed = ftpStr.trim()
+        if (trimmed.length === 0) {
+            onFtpChange(null)
+            return
+        }
+        const n = parseInt(trimmed, 10)
+        if (!isNaN(n) && n > 0) {
+            onFtpChange(n)
+        } else {
+            setFtpStr(ftpWatts !== null ? String(ftpWatts) : '')
+        }
     }
 
     function handleDescriptionBlur(): void {
@@ -137,25 +156,56 @@ export function WorkoutMetadataEditor({ workout, onSave, isSaving, onExport, isE
                 `}
             />
 
-            <textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                onBlur={handleDescriptionBlur}
-                disabled={isSaving}
-                aria-label="Workout description"
-                placeholder="Description"
-                rows={2}
-                maxLength={2000}
-                className={`
-                    w-full px-2 py-1
-                    bg-transparent text-zinc-300
-                    text-sm
-                    border border-transparent rounded
-                    hover:border-zinc-700 focus:border-brand-500
-                    focus:outline-none transition-colors resize-y
-                    disabled:opacity-50
-                `}
-            />
+            <div className="flex items-start gap-2">
+                <textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    onBlur={handleDescriptionBlur}
+                    disabled={isSaving}
+                    aria-label="Workout description"
+                    placeholder="Description"
+                    rows={2}
+                    maxLength={2000}
+                    className={`
+                        flex-1 min-w-0 px-2 py-1
+                        bg-transparent text-zinc-300
+                        text-sm
+                        border border-transparent rounded
+                        hover:border-zinc-700 focus:border-brand-500
+                        focus:outline-none transition-colors resize-y
+                        disabled:opacity-50
+                    `}
+                />
+
+                <div className="flex flex-col gap-1 shrink-0">
+                    <label className="text-xs text-zinc-500" htmlFor="ftp-input">
+                        FTP
+                    </label>
+                    <div className="flex items-center gap-1">
+                        <input
+                            id="ftp-input"
+                            type="number"
+                            min={1}
+                            max={999}
+                            value={ftpStr}
+                            onChange={(e) => setFtpStr(e.target.value)}
+                            onBlur={handleFtpBlur}
+                            aria-label="FTP in watts"
+                            placeholder="—"
+                            className={`
+                                w-16 px-2 py-1
+                                bg-transparent text-zinc-300
+                                text-sm text-right
+                                border border-transparent rounded
+                                hover:border-zinc-700 focus:border-brand-500
+                                focus:outline-none transition-colors
+                                [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none
+                            `}
+                        />
+                        <span className="text-xs text-zinc-500">W</span>
+                    </div>
+                </div>
+            </div>
         </div>
     )
 }

--- a/frontend/src/components/workout/WorkoutMetadataEditor.tsx
+++ b/frontend/src/components/workout/WorkoutMetadataEditor.tsx
@@ -69,8 +69,8 @@ export function WorkoutMetadataEditor({ workout, onSave, isSaving, onExport, isE
         })
     }
 
-    function handleFtpBlur(): void {
-        const trimmed = ftpStr.trim()
+    function commitFtp(raw: string): void {
+        const trimmed = raw.trim()
         if (trimmed.length === 0) {
             onFtpChange(null)
             return
@@ -80,6 +80,19 @@ export function WorkoutMetadataEditor({ workout, onSave, isSaving, onExport, isE
             onFtpChange(n)
         } else {
             setFtpStr(ftpWatts !== null ? String(ftpWatts) : '')
+        }
+    }
+
+    function handleFtpChange(value: string): void {
+        setFtpStr(value)
+        const trimmed = value.trim()
+        if (trimmed.length === 0) {
+            onFtpChange(null)
+        } else {
+            const n = parseInt(trimmed, 10)
+            if (!isNaN(n) && n > 0) {
+                onFtpChange(n)
+            }
         }
     }
 
@@ -188,8 +201,9 @@ export function WorkoutMetadataEditor({ workout, onSave, isSaving, onExport, isE
                             min={1}
                             max={999}
                             value={ftpStr}
-                            onChange={(e) => setFtpStr(e.target.value)}
-                            onBlur={handleFtpBlur}
+                            onChange={(e) => handleFtpChange(e.target.value)}
+                            onBlur={(e) => commitFtp(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur() }}
                             aria-label="FTP in watts"
                             placeholder="—"
                             className={`

--- a/frontend/src/utils/__tests__/workoutStats.test.ts
+++ b/frontend/src/utils/__tests__/workoutStats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDuration, totalDurationSeconds, normalisedPowerBeta } from '../workoutStats'
+import { formatDuration, totalDurationSeconds, normalisedPowerBeta, calculateNormalisedPower, calculateIntensityFactor, expandBarsToWatts } from '../workoutStats'
 import type { ChartBar } from '../intervalExpander'
 
 /** Builds a minimal ChartBar for testing stats functions. */
@@ -92,5 +92,79 @@ describe('normalisedPowerBeta', () => {
         // Weighted average: (83 * 1 + 98 * 2) / 3 = 279/3 = 93
         const bars = [makeBar(60, 83), makeBar(120, 98)]
         expect(normalisedPowerBeta(bars)).toBe(93)
+    })
+})
+
+describe('expandBarsToWatts', () => {
+    it('expands a single bar into one watt value per second', () => {
+        const bars = [makeBar(3, 100)]
+        // 100% of 200W FTP = 200W for each of 3 seconds
+        expect(expandBarsToWatts(bars, 200)).toEqual([200, 200, 200])
+    })
+
+    it('uses 0 watts for FreeRide bars', () => {
+        const freeRide: ChartBar = { ...makeBar(2, 0), style: 'freeride' }
+        expect(expandBarsToWatts([freeRide], 250)).toEqual([0, 0])
+    })
+
+    it('concatenates multiple bars in order', () => {
+        const bars = [makeBar(2, 50), makeBar(2, 100)]
+        // 50% of 200W = 100W, 100% of 200W = 200W
+        expect(expandBarsToWatts(bars, 200)).toEqual([100, 100, 200, 200])
+    })
+})
+
+describe('calculateNormalisedPower', () => {
+    it('returns null for fewer than 30 samples', () => {
+        const samples = Array(29).fill(200) as number[]
+        expect(calculateNormalisedPower(samples)).toBeNull()
+    })
+
+    it('returns NP equal to the constant power for a steady effort', () => {
+        // For constant power P, all rolling averages equal P, so NP = P
+        const samples = Array(60).fill(250) as number[]
+        expect(calculateNormalisedPower(samples)).toBe(250)
+    })
+
+    it('raises the rolling average to the 4th power before averaging', () => {
+        // NP > time-weighted mean for variable power (due to 4th power amplification)
+        // Two equal-length segments: 100W and 200W
+        // Time-weighted mean = 150W
+        // NP > 150W
+        const samples = [...Array(30).fill(100), ...Array(30).fill(200)] as number[]
+        const np = calculateNormalisedPower(samples)
+        expect(np).not.toBeNull()
+        expect(np!).toBeGreaterThan(150)
+    })
+
+    it('treats null values as 0 watts', () => {
+        const samples = [...Array(30).fill(null), ...Array(30).fill(200)] as (number | null)[]
+        const np = calculateNormalisedPower(samples as number[])
+        expect(np).not.toBeNull()
+    })
+
+    it('returns a value rounded to one decimal place', () => {
+        const samples = Array(60).fill(137.5) as number[]
+        const np = calculateNormalisedPower(samples)
+        expect(np).not.toBeNull()
+        // For constant power, NP = that power rounded to 1dp
+        expect(np).toBe(137.5)
+    })
+})
+
+describe('calculateIntensityFactor', () => {
+    it('returns NP divided by FTP, rounded to 2 decimal places', () => {
+        // IF = 250 / 250 = 1.00
+        expect(calculateIntensityFactor(250, 250)).toBe(1.0)
+    })
+
+    it('returns a value less than 1 for sub-threshold efforts', () => {
+        // IF = 200 / 250 = 0.80
+        expect(calculateIntensityFactor(200, 250)).toBe(0.8)
+    })
+
+    it('rounds to 2 decimal places', () => {
+        // IF = 233 / 250 = 0.932 → 0.93
+        expect(calculateIntensityFactor(233, 250)).toBe(0.93)
     })
 })

--- a/frontend/src/utils/workoutStats.ts
+++ b/frontend/src/utils/workoutStats.ts
@@ -48,3 +48,64 @@ export function normalisedPowerBeta(bars: ChartBar[]): number {
     )
     return Math.round(weighted / total)
 }
+
+/**
+ * Expands a list of chart bars into a flat per-second array of absolute
+ * power values in watts. FreeRide bars contribute 0W because they have no
+ * defined power target.
+ *
+ * @param bars the expanded chart bars for every section
+ * @param ftpWatts the user's FTP in watts, used to convert %FTP to watts
+ * @return array of watts values, one entry per second of workout duration
+ */
+export function expandBarsToWatts(bars: ChartBar[], ftpWatts: number): number[] {
+    const samples: number[] = []
+    for (const bar of bars) {
+        const watts = bar.style === 'freeride' ? 0 : (bar.powerPercent / 100) * ftpWatts
+        for (let s = 0; s < bar.durationSeconds; s++) {
+            samples.push(watts)
+        }
+    }
+    return samples
+}
+
+/**
+ * Calculates Normalised Power (NP) in watts using the standard 30-second
+ * rolling fourth-power algorithm.
+ *
+ * <p>Algorithm: replace nulls with 0, compute 30-second rolling averages,
+ * raise each to the 4th power, take the mean, then take the 4th root.</p>
+ *
+ * @param powerSamplesWatts per-second power values in watts; nulls treated as 0
+ * @return NP in watts rounded to 1 decimal place, or null if fewer than 30 samples
+ */
+export function calculateNormalisedPower(powerSamplesWatts: (number | null)[]): number | null {
+    const clean = powerSamplesWatts.map((v) => v ?? 0)
+    if (clean.length < 30) return null
+
+    const rollingAverages: number[] = []
+    for (let i = 0; i <= clean.length - 30; i++) {
+        let windowSum = 0
+        for (let j = i; j < i + 30; j++) {
+            windowSum += clean[j]
+        }
+        rollingAverages.push(windowSum / 30)
+    }
+
+    const meanFourthPower =
+        rollingAverages.reduce((sum, avg) => sum + avg ** 4, 0) / rollingAverages.length
+    const np = meanFourthPower ** 0.25
+
+    return Math.round(np * 10) / 10
+}
+
+/**
+ * Calculates Intensity Factor (IF) as the ratio of Normalised Power to FTP.
+ *
+ * @param npWatts Normalised Power in watts
+ * @param ftpWatts the user's FTP in watts
+ * @return IF rounded to 2 decimal places
+ */
+export function calculateIntensityFactor(npWatts: number, ftpWatts: number): number {
+    return Math.round((npWatts / ftpWatts) * 100) / 100
+}


### PR DESCRIPTION
## Issue
Closes #107 — Implement NP and IF display on workout canvas

## What was done
- Added `expandBarsToWatts`, `calculateNormalisedPower`, and `calculateIntensityFactor` to `src/utils/workoutStats.ts`; NP uses the standard 30-second rolling fourth-power algorithm
- Added an FTP input field to `WorkoutMetadataEditor` (right-aligned next to the description textarea) — stored at session level in `App.tsx` so it persists when switching workouts
- Updated `WorkoutCanvas` to compute NP in watts and IF when FTP is provided; both stats are hidden until the user enters an FTP value
- Added 14 unit tests for the three new utility functions

## Tests added
New tests in `src/utils/__tests__/workoutStats.test.ts`:
- `expandBarsToWatts` — 3 tests: single bar expansion, FreeRide = 0 W, multi-bar concatenation
- `calculateNormalisedPower` — 5 tests: null for < 30 samples, constant power, 4th-power amplification, null treated as 0 W, rounded to 1 dp
- `calculateIntensityFactor` — 3 tests: threshold effort = 1.00, sub-threshold, rounding to 2 dp

## Needs manual testing
- Open a workout without entering FTP — confirm NP and IF stats are not visible
- Enter an FTP value in the field next to the description — confirm NP (watts) and IF appear in the canvas footer
- Switch to a different workout — confirm the FTP value persists and stats recalculate for the new workout
- Clear the FTP field — confirm NP and IF disappear again

## Areas affected
**Frontend** — workout stats utilities, canvas footer, metadata editor, App session state (`workoutStats.ts`, `WorkoutCanvas.tsx`, `WorkoutMetadataEditor.tsx`, `App.tsx`)