### PR TITLE
[#147] Add focus trap, aria-dialog, and focus restoration to modals

### DIFF
--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,22 +1,113 @@
-import { useEffect, type JSX, type ReactNode } from 'react'
+import { useEffect, useRef, type JSX, type ReactNode } from 'react'
+
+/** Selector for all natively focusable elements inside a container. */
+const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(', ')
 
 interface Props {
     isOpen: boolean
     onClose: () => void
     title: string
     children: ReactNode
+    /**
+     * Optional id to use for the modal title element. When provided, the modal
+     * container sets aria-labelledby to this value so assistive technologies
+     * can announce the dialog name. If omitted, the id is derived automatically
+     * from the title string.
+     */
+    titleId?: string
 }
 
 /**
  * Shared modal wrapper. Renders a centred overlay with a panel containing
  * a title, close button, and the provided children. Closes on backdrop
  * click or Escape key.
+ *
+ * Accessibility features:
+ * - role="dialog" and aria-modal="true" on the panel container
+ * - aria-labelledby pointing to the title heading
+ * - aria-hidden="true" on the backdrop element
+ * - Focus trap: Tab and Shift+Tab cycle only within the open modal
+ * - Focus on open: moves focus to the first focusable element inside the panel
+ * - Focus restoration on close: returns focus to the element that opened the modal
  */
-export function Modal({ isOpen, onClose, title, children }: Props): JSX.Element | null {
+export function Modal({ isOpen, onClose, title, children, titleId }: Props): JSX.Element | null {
+    const panelRef = useRef<HTMLDivElement>(null)
+
+    // Derive a stable title id from the titleId prop or the title string.
+    // The title is lowercased and non-alphanumeric characters replaced with
+    // hyphens so that the resulting id is always a valid HTML attribute value.
+    const resolvedTitleId = titleId ?? `modal-title-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+
+    // Capture the element that triggered the modal so focus can be restored
+    // when the modal closes. The ref is populated when isOpen becomes true.
+    const triggerElementRef = useRef<Element | null>(null)
+
+    useEffect(() => {
+        if (isOpen) {
+            // Record the active element before the modal steals focus so we
+            // can return to it on close.
+            triggerElementRef.current = document.activeElement
+        }
+    }, [isOpen])
+
+    // Restore focus to the trigger element on unmount (i.e. when the modal
+    // closes and this component is removed from the tree).
+    useEffect(() => {
+        return () => {
+            const trigger = triggerElementRef.current
+            if (trigger instanceof HTMLElement) {
+                trigger.focus({ preventScroll: true })
+            }
+        }
+    }, [])
+
     useEffect(() => {
         function handleKeyDown(event: KeyboardEvent): void {
             if (event.key === 'Escape') {
                 onClose()
+                return
+            }
+
+            if (event.key !== 'Tab') {
+                return
+            }
+
+            const panel = panelRef.current
+            if (panel === null) {
+                return
+            }
+
+            const focusable = Array.from(
+                panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+            )
+
+            if (focusable.length === 0) {
+                event.preventDefault()
+                return
+            }
+
+            const first = focusable[0]
+            const last = focusable[focusable.length - 1]
+
+            if (event.shiftKey) {
+                // Shift+Tab: if focus is on the first element, wrap to last
+                if (document.activeElement === first) {
+                    event.preventDefault()
+                    last.focus()
+                }
+            } else {
+                // Tab: if focus is on the last element, wrap to first
+                if (document.activeElement === last) {
+                    event.preventDefault()
+                    first.focus()
+                }
             }
         }
 
@@ -27,27 +118,56 @@ export function Modal({ isOpen, onClose, title, children }: Props): JSX.Element 
         return () => document.removeEventListener('keydown', handleKeyDown)
     }, [isOpen, onClose])
 
+    // Move focus into the modal when it opens. The panel itself receives focus
+    // if no focusable child is found (tabIndex={-1} makes it programmatically
+    // focusable without adding it to the natural tab order).
+    useEffect(() => {
+        if (!isOpen) {
+            return
+        }
+
+        const panel = panelRef.current
+        if (panel === null) {
+            return
+        }
+
+        const firstFocusable = panel.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
+        if (firstFocusable !== null) {
+            firstFocusable.focus()
+        } else {
+            panel.focus()
+        }
+    }, [isOpen])
+
     if (!isOpen) {
         return null
     }
 
     return (
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+            className="fixed inset-0 z-50 flex items-center justify-center"
             onClick={onClose}
         >
+            {/* Purely visual backdrop — hidden from the accessibility tree */}
+            <div aria-hidden="true" className="absolute inset-0 bg-black/60" />
             <div
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={resolvedTitleId}
+                tabIndex={-1}
                 className={`
-                    flex flex-col
+                    relative flex flex-col
                     w-full max-w-md max-h-[90vh]
                     mx-4
                     bg-zinc-800 text-white
                     rounded-lg
+                    focus:outline-none
                 `}
                 onClick={(e) => e.stopPropagation()}
             >
                 <div className="flex items-center justify-between px-6 pt-6 pb-4 shrink-0">
-                    <h2 className="text-xl font-semibold">{title}</h2>
+                    <h2 id={resolvedTitleId} className="text-xl font-semibold">{title}</h2>
                     <button
                         onClick={onClose}
                         className="text-zinc-400 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:ring-offset-zinc-800 rounded"

--- a/frontend/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend/src/components/ui/__tests__/Modal.test.tsx
@@ -95,4 +95,115 @@ describe('Modal', () => {
         fireEvent.keyDown(document, { key: 'Escape' })
         expect(onClose).not.toHaveBeenCalled()
     })
+
+    describe('ARIA attributes', () => {
+        it('sets role="dialog" and aria-modal="true" on the panel', () => {
+            render(
+                <Modal isOpen onClose={vi.fn()} title="ARIA Test">
+                    <p>Content</p>
+                </Modal>
+            )
+            const dialog = screen.getByRole('dialog')
+            expect(dialog).toBeInTheDocument()
+            expect(dialog).toHaveAttribute('aria-modal', 'true')
+        })
+
+        it('sets aria-labelledby on the dialog pointing to the title heading', () => {
+            render(
+                <Modal isOpen onClose={vi.fn()} title="My Titled Modal">
+                    <p>Content</p>
+                </Modal>
+            )
+            const dialog = screen.getByRole('dialog')
+            const labelledById = dialog.getAttribute('aria-labelledby')
+            expect(labelledById).toBeTruthy()
+            const titleEl = document.getElementById(labelledById!)
+            expect(titleEl).not.toBeNull()
+            expect(titleEl?.textContent).toBe('My Titled Modal')
+        })
+
+        it('uses the provided titleId prop for aria-labelledby', () => {
+            render(
+                <Modal isOpen onClose={vi.fn()} title="Custom ID Modal" titleId="my-custom-title">
+                    <p>Content</p>
+                </Modal>
+            )
+            const dialog = screen.getByRole('dialog')
+            expect(dialog).toHaveAttribute('aria-labelledby', 'my-custom-title')
+            expect(document.getElementById('my-custom-title')?.textContent).toBe('Custom ID Modal')
+        })
+
+        it('sets aria-hidden="true" on the backdrop overlay', () => {
+            const { container } = render(
+                <Modal isOpen onClose={vi.fn()} title="Test">
+                    <p>Content</p>
+                </Modal>
+            )
+            // The backdrop is an absolute-positioned div inside the outer wrapper,
+            // separate from (and before) the dialog panel.
+            const backdrop = container.querySelector('[aria-hidden="true"]') as HTMLElement
+            expect(backdrop).not.toBeNull()
+            expect(backdrop).toHaveAttribute('aria-hidden', 'true')
+        })
+    })
+
+    describe('focus trap', () => {
+        it('wraps Tab from the last focusable element back to the first', () => {
+            render(
+                <Modal isOpen onClose={vi.fn()} title="Trap Test">
+                    <button>First</button>
+                    <button>Second</button>
+                </Modal>
+            )
+            const buttons = screen.getAllByRole('button')
+            // The close button rendered by Modal is the first focusable element;
+            // "Second" is the last.
+            const lastButton = buttons[buttons.length - 1]
+            lastButton.focus()
+            expect(document.activeElement).toBe(lastButton)
+
+            fireEvent.keyDown(document, { key: 'Tab', shiftKey: false })
+            // After wrapping, focus should be on the first focusable element
+            expect(document.activeElement).toBe(buttons[0])
+        })
+
+        it('wraps Shift+Tab from the first focusable element back to the last', () => {
+            render(
+                <Modal isOpen onClose={vi.fn()} title="Trap Test">
+                    <button>First</button>
+                    <button>Second</button>
+                </Modal>
+            )
+            const buttons = screen.getAllByRole('button')
+            // Focus the first button (the close button rendered by Modal)
+            buttons[0].focus()
+            expect(document.activeElement).toBe(buttons[0])
+
+            fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+            // After wrapping, focus should move to the last focusable element
+            const lastButton = buttons[buttons.length - 1]
+            expect(document.activeElement).toBe(lastButton)
+        })
+    })
+
+    describe('focus restoration', () => {
+        it('restores focus to the trigger element when the modal unmounts', () => {
+            const trigger = document.createElement('button')
+            document.body.appendChild(trigger)
+            trigger.focus()
+            expect(document.activeElement).toBe(trigger)
+
+            const { unmount } = render(
+                <Modal isOpen onClose={vi.fn()} title="Restore Test">
+                    <p>Content</p>
+                </Modal>
+            )
+
+            // Unmounting simulates the modal closing
+            unmount()
+            expect(document.activeElement).toBe(trigger)
+
+            document.body.removeChild(trigger)
+        })
+    })
 })


### PR DESCRIPTION
## Summary

- Adds `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the shared `Modal` component
- Implements a focus trap using `querySelectorAll` with a standard focusable-elements selector; Tab and Shift+Tab cycle only within the modal
- Restores focus to the previously focused element (`document.activeElement`) when the modal unmounts
- Restructured DOM: outer wrapper has no `aria-hidden`, backdrop is a sibling `<div aria-hidden="true">` so the dialog is never hidden from the accessibility tree

## Test plan

- [ ] Open any modal — focus should move to the panel immediately
- [ ] Tab through elements — focus should not leave the modal
- [ ] Close modal — focus should return to the element that triggered it
- [ ] Screen reader: modal should be announced as a dialog with its title

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)