### PR TITLE
[#150] Scale WorkoutCanvas SVG to container width using ResizeObserver

### DIFF
--- a/frontend/src/components/import/SectionSplitter.tsx
+++ b/frontend/src/components/import/SectionSplitter.tsx
@@ -15,6 +15,7 @@ import { useState, useRef, useMemo, type JSX } from 'react'
 import type { ParsedInterval, ParsedWorkout } from '../../types/workout'
 import { expandIntervalsToBars, type ChartBar } from '../../utils/intervalExpander'
 import { getColourForZone, getZoneForPower } from '../../utils/zoneColours'
+import { useContainerWidth } from '../../hooks/useContainerWidth'
 
 interface Props {
     workout: ParsedWorkout
@@ -46,11 +47,14 @@ const GROUP_INNER_GAP_SECONDS = 1
 /** Default Y-axis upper bound in percent FTP. Expands if any bar exceeds this. */
 const DEFAULT_Y_MAX_PERCENT = 140
 
-/** Assumed container width in screen pixels for aspect-ratio corner-radius compensation. */
-const ASSUMED_CONTAINER_PX = 700
-
 /** Corner radius in screen-pixel-equivalent SVG units. */
 const RY_PX = 4
+
+/**
+ * Minimum touch hit area in screen pixels for the boundary drag handles.
+ * 44px meets the WCAG 2.5.5 recommended touch target size.
+ */
+const MIN_TOUCH_HIT_PX = 44
 
 /**
  * Each empty-section zone is 20% of the total SVG width, so the bars occupy
@@ -84,6 +88,10 @@ export function SectionSplitter({ workout, onConfirm, onCancel, isSaving }: Prop
     const [cooldownStart, setCooldownStart] = useState(intervalCount)
     const [boundaryDrag, setBoundaryDrag] = useState<BoundaryDrag | null>(null)
     const svgRef = useRef<SVGSVGElement | null>(null)
+
+    // Measure the actual rendered container width so corner radii and hit areas
+    // are scaled correctly regardless of viewport size.
+    const { ref: chartContainerRef, width: containerWidth } = useContainerWidth(700)
 
     const bars = useMemo(
         () => expandIntervalsToBars(intervals, 'split'),
@@ -230,7 +238,7 @@ export function SectionSplitter({ workout, onConfirm, onCancel, isSaving }: Prop
                 Drag the handles to define where the warm-up ends and cool-down begins.
             </p>
 
-            <div className="flex flex-col w-full px-3 py-3 bg-zinc-800/40 border border-zinc-700 rounded-lg overflow-hidden">
+            <div ref={chartContainerRef} className="flex flex-col w-full px-3 py-3 bg-zinc-800/40 border border-zinc-700 rounded-lg overflow-hidden">
                 {/* Section label row: each label floats at the centre of its section. */}
                 <div className="relative h-5 mb-1">
                     <span
@@ -326,6 +334,7 @@ export function SectionSplitter({ workout, onConfirm, onCancel, isSaving }: Prop
                             x={barsXOffset + barLocalX[i]}
                             yMax={yMax}
                             svgTotalWidth={totalSvgWidth}
+                            containerWidth={containerWidth}
                         />
                     ))}
 
@@ -334,6 +343,8 @@ export function SectionSplitter({ workout, onConfirm, onCancel, isSaving }: Prop
                         x={wuBoundaryX}
                         isActive={boundaryDrag !== null && boundaryDrag.which === 'WU'}
                         onPointerDown={(e) => handleBoundaryPointerDown('WU', e)}
+                        svgTotalWidth={totalSvgWidth}
+                        containerWidth={containerWidth}
                     />
 
                     {/* Main Set / Cool-Down boundary handle */}
@@ -341,6 +352,8 @@ export function SectionSplitter({ workout, onConfirm, onCancel, isSaving }: Prop
                         x={cdBoundaryX}
                         isActive={boundaryDrag !== null && boundaryDrag.which === 'CD'}
                         onPointerDown={(e) => handleBoundaryPointerDown('CD', e)}
+                        svgTotalWidth={totalSvgWidth}
+                        containerWidth={containerWidth}
                     />
                 </svg>
             </div>
@@ -412,21 +425,29 @@ interface BoundaryHandleProps {
     x: number
     isActive: boolean
     onPointerDown: (e: React.PointerEvent) => void
+    /** Full SVG viewBox width in SVG units (seconds). Used to convert px to SVG units. */
+    svgTotalWidth: number
+    /** Measured container width in screen pixels. Used to guarantee the 44px touch target. */
+    containerWidth: number
 }
 
 /**
  * A draggable vertical boundary handle rendered as a bright green line with a
  * rounded capsule grip at the centre. The capsule uses vectorEffect so it
  * renders at a fixed screen-pixel size regardless of SVG aspect ratio.
- * A wider invisible rect provides a generous pointer target.
+ * A wider invisible rect provides a touch-friendly pointer target (minimum 44px).
  */
-function BoundaryHandle({ x, isActive, onPointerDown }: BoundaryHandleProps): JSX.Element {
+function BoundaryHandle({ x, isActive, onPointerDown, svgTotalWidth, containerWidth }: BoundaryHandleProps): JSX.Element {
     const idleColour = 'rgba(34, 197, 94, 0.75)'
     const activeColour = 'rgba(34, 197, 94, 1.0)'
     const colour = isActive ? activeColour : idleColour
     const lineWidth = isActive ? 2.5 : 2
     const capsuleWidth = isActive ? 12 : 10
-    const hitAreaWidth = 20
+
+    // Convert the minimum touch hit area from screen pixels to SVG units.
+    // The SVG is scaled non-uniformly so we derive the ratio from the measured container.
+    const svgUnitsPerPx = containerWidth > 0 ? svgTotalWidth / containerWidth : 1
+    const hitAreaWidth = Math.max(20, MIN_TOUCH_HIT_PX * svgUnitsPerPx)
 
     return (
         <g onPointerDown={onPointerDown} style={{ cursor: 'col-resize' }}>
@@ -487,6 +508,8 @@ interface SplitBarShapeProps {
     x: number
     yMax: number
     svgTotalWidth: number
+    /** Measured container width in screen pixels. Used for aspect-ratio corner-radius compensation. */
+    containerWidth: number
 }
 
 /**
@@ -494,8 +517,11 @@ interface SplitBarShapeProps {
  * Supports flat, ramp, and free-ride bar styles with zone colouring,
  * matching the appearance of the main workout canvas.
  */
-function SplitBarShape({ bar, x, yMax, svgTotalWidth }: SplitBarShapeProps): JSX.Element {
+function SplitBarShape({ bar, x, yMax, svgTotalWidth, containerWidth }: SplitBarShapeProps): JSX.Element {
     const ry = RY_PX
+    // Use the measured container width instead of a hardcoded assumption so
+    // corner radii look correct on any viewport width.
+    const effectiveContainerPx = containerWidth > 0 ? containerWidth : 700
 
     if (bar.style === 'ramp' && bar.startPowerPercent !== null && bar.endPowerPercent !== null) {
         const startHeight = (bar.startPowerPercent / yMax) * PLOT_HEIGHT
@@ -504,7 +530,7 @@ function SplitBarShape({ bar, x, yMax, svgTotalWidth }: SplitBarShapeProps): JSX
         const endY = PLOT_HEIGHT - endHeight
         const w = bar.durationSeconds
         const rx = Math.min(
-            RY_PX * svgTotalWidth / ASSUMED_CONTAINER_PX,
+            RY_PX * svgTotalWidth / effectiveContainerPx,
             w * 0.25,
             startHeight * 0.15,
             endHeight * 0.15,
@@ -563,7 +589,7 @@ function SplitBarShape({ bar, x, yMax, svgTotalWidth }: SplitBarShapeProps): JSX
     const y = PLOT_HEIGHT - height
     const w = bar.durationSeconds
     const fill = getColourForZone(getZoneForPower(bar.powerPercent))
-    const rxFlat = Math.min(RY_PX * svgTotalWidth / ASSUMED_CONTAINER_PX, w * 0.25)
+    const rxFlat = Math.min(RY_PX * svgTotalWidth / effectiveContainerPx, w * 0.25)
     const ryFlat = Math.min(ry, height / 3)
     const rectPath = [
         `M ${x + rxFlat},${y}`,

--- a/frontend/src/components/workout/WorkoutCanvas.tsx
+++ b/frontend/src/components/workout/WorkoutCanvas.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, type JSX } from 'react'
+import { useContainerWidth } from '../../hooks/useContainerWidth'
 import type { BlockDetail, ParsedInterval, SectionType, WorkoutDetail } from '../../types/workout'
 import { expandIntervalsToBars, type ChartBar } from '../../utils/intervalExpander'
 import { getColourForZone, getZoneForPower } from '../../utils/zoneColours'
@@ -822,7 +823,10 @@ function ChartArea({
     onMoveTextEvent,
 }: ChartAreaProps): JSX.Element {
     const svgRef = useRef<SVGSVGElement | null>(null)
-    const containerRef = useRef<HTMLDivElement | null>(null)
+    // Measure the real container width so corner radii and hit areas are
+    // accurate on any viewport. The ref doubles as the existing containerRef
+    // used for text event drag position calculation.
+    const { ref: containerRef, width: containerWidth } = useContainerWidth(700)
     const [boundaryDragActive, setBoundaryDragActive] = useState<BoundaryDragActive | null>(null)
     // Each boundary tracks its own pending state so both can be moved before saving.
     const [wuMsPending, setWuMsPending] = useState<{ count: number; snapPositions: number[] } | null>(null)
@@ -1409,6 +1413,7 @@ function ChartArea({
                         layouts={layouts}
                         totalWidth={totalWidth}
                         yMax={yMax}
+                        containerWidth={containerWidth}
                         onSelectInterval={
                             barDragState === null && resizeDragState === null && paletteDragState === null
                                 ? onSelectInterval
@@ -1707,6 +1712,8 @@ interface UnifiedChartProps {
     layouts: SectionLayout[]
     totalWidth: number
     yMax: number
+    /** Measured container width in screen pixels, used for corner radius and hit area scaling. */
+    containerWidth: number
     onSelectInterval?: (sectionType: SectionType, intervalIndex: number) => void
     selectedInterval: { sectionType: SectionType; intervalIndex: number } | null
     wuMsHandleX: number
@@ -1757,6 +1764,7 @@ function UnifiedChart({
     layouts,
     totalWidth,
     yMax,
+    containerWidth,
     onSelectInterval,
     selectedInterval,
     wuMsHandleX,
@@ -1817,6 +1825,7 @@ function UnifiedChart({
                     layout.section.type,
                     layout.xOffset,
                     totalWidth,
+                    containerWidth,
                     onSelectInterval,
                     selectedInterval?.sectionType === layout.section.type
                         ? selectedInterval.intervalIndex
@@ -1847,6 +1856,7 @@ function UnifiedChart({
                         yMax,
                         barDragState.pointerSvgX - barDragState.grabOffsetX,
                         totalWidth,
+                        containerWidth,
                     )}
                 </g>
             )}
@@ -1890,6 +1900,8 @@ function UnifiedChart({
                     canMove={canMoveBoundary && !isDraggingBar}
                     onPointerDown={onBoundaryPointerDown}
                     isDraggingBoundary={isDraggingBoundary}
+                    svgTotalWidth={totalWidth}
+                    containerWidth={containerWidth}
                 />
             )}
 
@@ -1903,11 +1915,19 @@ function UnifiedChart({
                     canMove={canMoveBoundary && !isDraggingBar}
                     onPointerDown={onBoundaryPointerDown}
                     isDraggingBoundary={isDraggingBoundary}
+                    svgTotalWidth={totalWidth}
+                    containerWidth={containerWidth}
                 />
             )}
         </svg>
     )
 }
+
+/**
+ * Minimum touch hit area in screen pixels for boundary drag handles.
+ * 44px meets the WCAG 2.5.5 recommended touch target size.
+ */
+const MIN_TOUCH_HIT_PX = 44
 
 interface BoundaryHandleProps {
     x: number
@@ -1917,12 +1937,17 @@ interface BoundaryHandleProps {
     canMove: boolean
     onPointerDown: (boundary: 'WU_MS' | 'MS_CD', e: React.PointerEvent) => void
     isDraggingBoundary: boolean
+    /** Full SVG viewBox width in SVG units. Used to convert screen px to SVG units. */
+    svgTotalWidth: number
+    /** Measured container width in screen pixels. Used to guarantee the 44px touch target. */
+    containerWidth: number
 }
 
 /**
  * A draggable vertical handle rendered between two sections. The handle is a
  * subtle line with small tick marks, styled to hint at interactivity without
- * dominating the chart.
+ * dominating the chart. The hit area is scaled to meet the 44px minimum touch
+ * target regardless of viewport width.
  */
 function BoundaryHandle({
     x,
@@ -1932,6 +1957,8 @@ function BoundaryHandle({
     canMove,
     onPointerDown,
     isDraggingBoundary,
+    svgTotalWidth,
+    containerWidth,
 }: BoundaryHandleProps): JSX.Element {
     const colour = isActive
         ? 'rgba(255,255,255,0.9)'
@@ -1940,8 +1967,10 @@ function BoundaryHandle({
         : 'rgba(161,161,170,0.35)' // subtle zinc when idle
 
     const cursor = canMove && !isDraggingBoundary ? 'col-resize' : 'default'
-    // A wider invisible rect behind the line gives a larger pointer target
-    const hitAreaWidth = 12
+    // Convert the minimum touch hit area from screen pixels to SVG units so the
+    // pointer target meets WCAG 2.5.5 regardless of how the SVG is scaled.
+    const svgUnitsPerPx = containerWidth > 0 ? svgTotalWidth / containerWidth : 1
+    const hitAreaWidth = Math.max(12, MIN_TOUCH_HIT_PX * svgUnitsPerPx)
 
     return (
         <g
@@ -1993,6 +2022,8 @@ function BoundaryHandle({
  * @param xOffset                    offset added to every bar's local x position
  * @param svgTotalWidth              full SVG viewBox width in seconds, used to compute
  *                                   aspect-ratio-compensated corner radii
+ * @param containerWidth             measured container width in screen pixels, paired with
+ *                                   svgTotalWidth to produce accurate screen-pixel conversions
  * @param onSelectInterval           called when the user clicks a bar
  * @param selectedIndex              interval index that should receive a highlight stroke
  * @param onBarPointerDown           called when the user initiates a drag on a bar
@@ -2008,6 +2039,7 @@ function buildSectionShapes(
     sectionType: SectionType,
     xOffset: number,
     svgTotalWidth: number,
+    containerWidth: number,
     onSelectInterval: ((sectionType: SectionType, intervalIndex: number) => void) | undefined,
     selectedIndex: number | null,
     onBarPointerDown:
@@ -2119,6 +2151,7 @@ function buildSectionShapes(
                 x={cursor}
                 yMax={yMax}
                 svgTotalWidth={svgTotalWidth}
+                containerWidth={containerWidth}
                 isSelected={isSelected}
                 isDragging={isDragging}
                 onClick={handleClick}
@@ -2146,6 +2179,7 @@ function buildGhostShapes(
     yMax: number,
     ghostX: number,
     svgTotalWidth: number,
+    containerWidth: number,
 ): JSX.Element[] {
     const shapes: JSX.Element[] = []
     let cursor = ghostX
@@ -2166,6 +2200,7 @@ function buildGhostShapes(
                 x={cursor}
                 yMax={yMax}
                 svgTotalWidth={svgTotalWidth}
+                containerWidth={containerWidth}
                 isSelected={false}
                 isDragging={false}
             />,
@@ -2187,6 +2222,12 @@ interface BarShapeProps {
      * preserveAspectRatio="none", so corners look circular rather than sloped.
      */
     svgTotalWidth: number
+    /**
+     * Measured container width in screen pixels. Used alongside svgTotalWidth
+     * to convert screen-pixel constants (corner radii, hit areas) into correct
+     * SVG units at any viewport width.
+     */
+    containerWidth: number
     isSelected: boolean
     /** True when this bar is the one being dragged. Renders faded. */
     isDragging: boolean
@@ -2225,6 +2266,7 @@ function BarShape({
     x,
     yMax,
     svgTotalWidth,
+    containerWidth,
     isSelected,
     isDragging,
     onClick,
@@ -2247,13 +2289,11 @@ function BarShape({
 
     // The SVG uses preserveAspectRatio="none" with a fixed height of PLOT_HEIGHT
     // px. This means 1 SVG y-unit = 1px exactly, but 1 SVG x-unit varies by
-    // workout duration. To produce circular-looking corners, ry is fixed in
-    // SVG units (= px) and rx is scaled by the viewBox aspect ratio.
-    // ASSUMED_CONTAINER_PX is a reasonable estimate of the rendered container
-    // width in screen pixels; the assumption only affects how circular the
-    // corners appear, not correctness.
-    const ASSUMED_CONTAINER_PX = 700
+    // workout duration and container width. To produce circular-looking corners,
+    // ry is fixed in SVG units (= px) and rx is scaled by the actual viewBox
+    // aspect ratio derived from the measured container width.
     const RY_PX = 4
+    const effectiveContainerPx = containerWidth > 0 ? containerWidth : 700
     const ry = RY_PX   // SVG y-units ≈ screen px since height is fixed 1:1
 
     if (bar.style === 'ramp' && bar.startPowerPercent !== null && bar.endPowerPercent !== null) {
@@ -2266,7 +2306,7 @@ function BarShape({
         // rx compensates for non-uniform SVG scaling so corners look circular.
         // Capped at 25% of bar width and 15% of each end height.
         const rx = Math.min(
-            RY_PX * svgTotalWidth / ASSUMED_CONTAINER_PX,
+            RY_PX * svgTotalWidth / effectiveContainerPx,
             w * 0.25,
             startHeight * 0.15,
             endHeight * 0.15,
@@ -2310,7 +2350,7 @@ function BarShape({
         const gradientId = `ramp-${x}-${bar.durationSeconds}`
 
         const HANDLE_HIT_PX_RAMP = 8
-        const hitWRamp = Math.min(HANDLE_HIT_PX_RAMP * svgTotalWidth / ASSUMED_CONTAINER_PX, w * 0.4)
+        const hitWRamp = Math.min(HANDLE_HIT_PX_RAMP * svgTotalWidth / effectiveContainerPx, w * 0.4)
         const isResizingRamp = liveDurationSeconds !== undefined
         const rampRightLineColour = hoverRight || isResizingRamp
             ? 'rgba(255,255,255,0.85)'
@@ -2410,7 +2450,7 @@ function BarShape({
     const fill = getColourForZone(getZoneForPower(renderPower))
     // rx compensates for non-uniform SVG scaling; ry is in px-equivalent units.
     // Both are capped to prevent over-rounding short or flat bars.
-    const rxFlat = Math.min(RY_PX * svgTotalWidth / ASSUMED_CONTAINER_PX, w * 0.25)
+    const rxFlat = Math.min(RY_PX * svgTotalWidth / effectiveContainerPx, w * 0.25)
     const ryFlat = Math.min(ry, height / 3)
     // Axis-aligned edges allow separate rx/ry in the path for a proper elliptical
     // corner. Only the top two corners are rounded; the bottom stays flush.
@@ -2448,7 +2488,7 @@ function BarShape({
     // Same technique as rxFlat above. Capped at 40% of the bar dimension so
     // handles never swamp a very short or very flat bar.
     const HANDLE_HIT_PX = 8
-    const hitWRight = Math.min(HANDLE_HIT_PX * svgTotalWidth / ASSUMED_CONTAINER_PX, w * 0.4)
+    const hitWRight = Math.min(HANDLE_HIT_PX * svgTotalWidth / effectiveContainerPx, w * 0.4)
     const hitHTop = Math.min(HANDLE_HIT_PX, height * 0.4)
 
     // Active drag detection for styling: live values are only passed when this

--- a/frontend/src/hooks/useContainerWidth.ts
+++ b/frontend/src/hooks/useContainerWidth.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+
+/**
+ * Measures the pixel width of a container element using a ResizeObserver.
+ * Returns a ref to attach to the container and the observed width in pixels.
+ * Defaults to the provided fallback until the first measurement fires.
+ *
+ * @param fallback  width in pixels to use before the first measurement, e.g. 700
+ */
+export function useContainerWidth(fallback: number = 700): {
+    ref: RefObject<HTMLDivElement | null>
+    width: number
+} {
+    const ref = useRef<HTMLDivElement | null>(null)
+    const [width, setWidth] = useState<number>(fallback)
+
+    useEffect(() => {
+        if (ref.current === null) return
+
+        // Measure immediately on mount so the first render uses the real width.
+        const initialWidth = ref.current.getBoundingClientRect().width
+        if (initialWidth > 0) {
+            setWidth(initialWidth)
+        }
+
+        const observer = new ResizeObserver((entries) => {
+            const entry = entries[0]
+            if (entry === undefined) return
+            const measured = entry.contentRect.width
+            if (measured > 0) {
+                setWidth(measured)
+            }
+        })
+
+        observer.observe(ref.current)
+        return () => {
+            observer.disconnect()
+        }
+    }, [])
+
+    return { ref, width }
+}


### PR DESCRIPTION
## Summary

- Adds `useContainerWidth` hook that uses `ResizeObserver` to measure a ref'd element's `contentRect.width`, defaulting to 700px until the first measurement
- Threads the measured width through `WorkoutCanvas` → `ChartArea` → `UnifiedChart` → `buildSectionShapes`, replacing all hard-coded 700px constants
- Applies the same measurement to `SectionSplitter`, removing the `ASSUMED_CONTAINER_PX` constant
- Section boundary drag handles and boundary hit areas scale to guarantee a minimum 44px touch target at any container width

## Test plan

- [ ] Resize the browser window — the workout bar chart should reflow to fill the available width at every size
- [ ] On mobile: chart should fill the screen width, not be clipped or scrollable horizontally
- [ ] Section splitter (import flow) should also size correctly

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)