### PR TITLE
[#151] Announce loading and error states to screen readers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -964,8 +964,11 @@ export function App(): JSX.Element {
 
     if (isLoading) {
         return (
-            <div className="flex items-center justify-center min-h-screen bg-zinc-900 text-white">
-                <p className="text-zinc-400 text-sm">Loading...</p>
+            <div
+                className="flex items-center justify-center min-h-screen bg-zinc-900 text-white"
+                aria-busy="true"
+            >
+                <p role="status" aria-live="polite" className="text-zinc-400 text-sm">Loading...</p>
             </div>
         )
     }
@@ -1138,13 +1141,13 @@ export function App(): JSX.Element {
                             )}
 
                             {saveSuccess && (
-                                <p className="px-3 py-2 bg-green-900/40 text-green-300 text-sm rounded-md">
+                                <p role="status" aria-live="polite" className="px-3 py-2 bg-green-900/40 text-green-300 text-sm rounded-md">
                                     {saveSuccess}
                                 </p>
                             )}
 
                             {saveError && (
-                                <p className="px-3 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
+                                <p role="alert" className="px-3 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
                                     {saveError}
                                 </p>
                             )}
@@ -1167,7 +1170,7 @@ export function App(): JSX.Element {
                         )}
 
                         {exportError !== null && (
-                            <p className="text-sm text-red-300">{exportError}</p>
+                            <p role="alert" className="text-sm text-red-300">{exportError}</p>
                         )}
 
                         <WorkoutCanvas
@@ -1226,19 +1229,19 @@ export function App(): JSX.Element {
                         )}
 
                         {metadataError && (
-                            <p className="px-4 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
+                            <p role="alert" className="px-4 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
                                 {metadataError}
                             </p>
                         )}
 
                         {undoError && (
-                            <p className="px-4 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
+                            <p role="alert" className="px-4 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
                                 {undoError}
                             </p>
                         )}
 
                         {isAuthenticated && autosaveStatus === 'error' && autosaveError && (
-                            <p className="px-4 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
+                            <p role="alert" className="px-4 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
                                 Auto-save failed: {autosaveError}
                             </p>
                         )}

--- a/frontend/src/components/auth/SignInModal.tsx
+++ b/frontend/src/components/auth/SignInModal.tsx
@@ -120,7 +120,7 @@ export function SignInModal({ isOpen, onClose, onSignIn, showGuestWarning = fals
                 </div>
 
                 {error && (
-                    <p className="text-sm text-red-400 text-center">{error}</p>
+                    <p role="alert" className="text-sm text-red-400 text-center">{error}</p>
                 )}
 
                 <button

--- a/frontend/src/components/auth/SignUpModal.tsx
+++ b/frontend/src/components/auth/SignUpModal.tsx
@@ -125,7 +125,7 @@ export function SignUpModal({ isOpen, onClose, onSignUp, showGuestWarning = fals
                         autoComplete="email"
                     />
                     {emailError && (
-                        <p className="text-sm text-red-400">{emailError}</p>
+                        <p role="alert" className="text-sm text-red-400">{emailError}</p>
                     )}
                 </div>
 
@@ -154,12 +154,12 @@ export function SignUpModal({ isOpen, onClose, onSignUp, showGuestWarning = fals
                         autoComplete="new-password"
                     />
                     {passwordError && (
-                        <p className="text-sm text-red-400">{passwordError}</p>
+                        <p role="alert" className="text-sm text-red-400">{passwordError}</p>
                     )}
                 </div>
 
                 {serverError && (
-                    <p className="text-sm text-red-400 text-center">{serverError}</p>
+                    <p role="alert" className="text-sm text-red-400 text-center">{serverError}</p>
                 )}
 
                 <button

--- a/frontend/src/components/blocks/BlockLibrary.tsx
+++ b/frontend/src/components/blocks/BlockLibrary.tsx
@@ -37,8 +37,11 @@ export function BlockLibrary({ blocks, isLoading, error, onEditBlock, onDeleteBl
 
     if (isLoading) {
         return (
-            <div className="w-full px-4 py-4 bg-zinc-800/40 border border-zinc-700 rounded-lg">
-                <p className="text-sm text-zinc-400">Loading library...</p>
+            <div
+                className="w-full px-4 py-4 bg-zinc-800/40 border border-zinc-700 rounded-lg"
+                aria-busy="true"
+            >
+                <p role="status" aria-live="polite" className="text-sm text-zinc-400">Loading library...</p>
             </div>
         )
     }
@@ -46,7 +49,7 @@ export function BlockLibrary({ blocks, isLoading, error, onEditBlock, onDeleteBl
     if (error !== null) {
         return (
             <div className="w-full px-4 py-4 bg-red-900/30 border border-red-800 rounded-lg">
-                <p className="text-sm text-red-300">{error}</p>
+                <p role="alert" className="text-sm text-red-300">{error}</p>
             </div>
         )
     }

--- a/frontend/src/components/blocks/BulkReplaceModal.tsx
+++ b/frontend/src/components/blocks/BulkReplaceModal.tsx
@@ -180,7 +180,7 @@ export function BulkReplaceModal({
                 </label>
 
                 {error !== null && (
-                    <p className="text-sm text-red-400">{error}</p>
+                    <p role="alert" className="text-sm text-red-400">{error}</p>
                 )}
 
                 <div className="flex justify-end gap-3">

--- a/frontend/src/components/blocks/CreateBlockModal.tsx
+++ b/frontend/src/components/blocks/CreateBlockModal.tsx
@@ -303,7 +303,7 @@ export function CreateBlockModal({ isOpen, onClose, onSaved, initialBlock = null
                     </div>
 
                     {error !== null && (
-                        <p className="text-sm text-red-400">{error}</p>
+                        <p role="alert" className="text-sm text-red-400">{error}</p>
                     )}
 
                     {/* Footer */}

--- a/frontend/src/components/blocks/ReplaceWithBlockModal.tsx
+++ b/frontend/src/components/blocks/ReplaceWithBlockModal.tsx
@@ -95,7 +95,7 @@ export function ReplaceWithBlockModal({
                 )}
 
                 {error !== null && (
-                    <p className="text-sm text-red-400">{error}</p>
+                    <p role="alert" className="text-sm text-red-400">{error}</p>
                 )}
 
                 <div className="flex justify-end gap-3 mt-2">

--- a/frontend/src/components/blocks/SaveToLibraryModal.tsx
+++ b/frontend/src/components/blocks/SaveToLibraryModal.tsx
@@ -122,7 +122,7 @@ export function SaveToLibraryModal({
                 </div>
 
                 {error !== null && (
-                    <p className="text-sm text-red-400">{error}</p>
+                    <p role="alert" className="text-sm text-red-400">{error}</p>
                 )}
 
                 <div className="flex justify-end gap-3 mt-2">

--- a/frontend/src/components/workout/WorkoutCanvas.tsx
+++ b/frontend/src/components/workout/WorkoutCanvas.tsx
@@ -307,8 +307,11 @@ export function WorkoutCanvas({
 }: Props): JSX.Element {
     if (isLoading) {
         return (
-            <div className="w-full px-4 py-12 bg-zinc-800/40 border border-zinc-700 rounded-lg text-center">
-                <p className="text-sm text-zinc-400">Loading workout...</p>
+            <div
+                className="w-full px-4 py-12 bg-zinc-800/40 border border-zinc-700 rounded-lg text-center"
+                aria-busy="true"
+            >
+                <p role="status" aria-live="polite" className="text-sm text-zinc-400">Loading workout...</p>
             </div>
         )
     }
@@ -316,7 +319,7 @@ export function WorkoutCanvas({
     if (error) {
         return (
             <div className="w-full px-4 py-12 bg-red-900/30 border border-red-800 rounded-lg text-center">
-                <p className="text-sm text-red-300">{error}</p>
+                <p role="alert" className="text-sm text-red-300">{error}</p>
             </div>
         )
     }

--- a/frontend/src/components/workout/WorkoutList.tsx
+++ b/frontend/src/components/workout/WorkoutList.tsx
@@ -131,11 +131,11 @@ export function WorkoutList({
                 save we keep showing the existing list so the layout does
                 not collapse and the focused field stays in place. */}
             {isLoading && workouts.length === 0 && (
-                <p className="text-sm text-zinc-400">Loading workouts...</p>
+                <p role="status" aria-live="polite" className="text-sm text-zinc-400">Loading workouts...</p>
             )}
 
             {error && !isLoading && (
-                <p className="px-3 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
+                <p role="alert" className="px-3 py-2 bg-red-900/40 text-red-300 text-sm rounded-md">
                     {error}
                 </p>
             )}


### PR DESCRIPTION
## Summary

- Loading spinners/containers get `aria-busy="true"` and `role="status" aria-live="polite"` so screen readers announce when content is loading and when it finishes
- Error messages get `role="alert"` for immediate announcement (assertive live region)
- Save/action success messages get `role="status" aria-live="polite"` for non-disruptive confirmation
- Affected components: `WorkoutCanvas`, `App.tsx` (workout list loading), all modal error messages

## Test plan

- [ ] With a screen reader (VoiceOver or NVDA): loading spinner should be announced
- [ ] Triggering an error should be announced immediately without waiting for focus
- [ ] Successful saves should be announced politely without interrupting the user

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)