### PR TITLE
[#152] Replace role="button" div with semantic button in BlockCard

### DIFF
--- a/frontend/src/components/blocks/BlockCard.tsx
+++ b/frontend/src/components/blocks/BlockCard.tsx
@@ -25,9 +25,10 @@ const SECTION_LABELS: Record<SectionType, string> = {
  * Highlights when selected. Includes a delete button with an inline
  * confirmation step to prevent accidental deletion.
  *
- * <p>The entire card surface is the click target. The delete icon and
- * confirmation buttons call {@code e.stopPropagation()} so they do not
- * accidentally trigger the card select.</p>
+ * The card uses a relative-positioned wrapper with an absolutely-positioned
+ * primary action button covering the full card surface. Edit and delete buttons
+ * sit above the primary button via z-index, so they do not nest inside it,
+ * which would be invalid HTML.
  */
 export function BlockCard({ block, isSelected, onClick, onEdit = undefined, onDelete = undefined }: Props): JSX.Element {
     const [isPendingDelete, setIsPendingDelete] = useState(false)
@@ -47,32 +48,30 @@ export function BlockCard({ block, isSelected, onClick, onEdit = undefined, onDe
         onDelete?.()
     }
 
-    function handleKeyDown(e: React.KeyboardEvent): void {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            onClick()
-        }
-    }
-
     return (
+        // Relative positioning allows the primary action button to fill the card
+        // with absolute inset-0, while action buttons sit above it via z-10.
         <div
-            role="button"
-            tabIndex={0}
-            onClick={onClick}
-            onKeyDown={handleKeyDown}
             className={`
-                flex flex-col gap-1 text-left
+                relative flex flex-col gap-1
                 w-full px-3 py-2
                 border rounded-lg
-                cursor-pointer transition-colors
-                focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:ring-offset-zinc-900
+                transition-colors
                 ${isSelected
                     ? 'bg-zinc-700 border-brand-500'
                     : 'bg-zinc-800 border-zinc-700 hover:bg-zinc-700 hover:border-zinc-600'}
             `}
         >
-            {/* Header row: section badge, stats, and delete button */}
-            <div className="flex items-center justify-between gap-2">
+            {/* Primary action button covers the entire card surface */}
+            <button
+                type="button"
+                aria-label={`Select block ${block.name}`}
+                onClick={onClick}
+                className="absolute inset-0 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:ring-offset-zinc-900"
+            />
+
+            {/* Header row: section badge, stats, and action buttons — above the primary button via z-10 */}
+            <div className="relative z-10 flex items-center justify-between gap-2">
                 <span
                     className={`
                         px-1.5 py-0.5
@@ -135,15 +134,15 @@ export function BlockCard({ block, isSelected, onClick, onEdit = undefined, onDe
                 </div>
             </div>
 
-            {/* Block name and description */}
-            <p className="text-sm font-medium text-white truncate">{block.name}</p>
+            {/* Block name and description — above the primary button via z-10 */}
+            <p className="relative z-10 text-sm font-medium text-white truncate">{block.name}</p>
             {block.description !== null && block.description.length > 0 && (
-                <p className="text-xs text-zinc-400 line-clamp-2">{block.description}</p>
+                <p className="relative z-10 text-xs text-zinc-400 line-clamp-2">{block.description}</p>
             )}
 
-            {/* Inline delete confirmation */}
+            {/* Inline delete confirmation — above the primary button via z-10 */}
             {onDelete !== undefined && isPendingDelete && (
-                <div className="flex items-center justify-between gap-2 mt-1 pt-1 border-t border-zinc-600">
+                <div className="relative z-10 flex items-center justify-between gap-2 mt-1 pt-1 border-t border-zinc-600">
                     <p className="text-xs text-zinc-300">Delete this block?</p>
                     <div className="flex gap-2">
                         <button

--- a/frontend/src/components/blocks/__tests__/BlockCard.test.tsx
+++ b/frontend/src/components/blocks/__tests__/BlockCard.test.tsx
@@ -67,20 +67,20 @@ describe('BlockCard', () => {
         expect(screen.queryByText(/1 intervals/)).not.toBeInTheDocument()
     })
 
-    it('calls onClick when the card is clicked', async () => {
+    it('calls onClick when the card primary button is clicked', async () => {
         const user = userEvent.setup()
         const onClick = vi.fn()
         renderBlockCard({ onClick })
-        await user.click(screen.getByRole('button'))
+        await user.click(screen.getByRole('button', { name: /select block threshold 3x8/i }))
         expect(onClick).toHaveBeenCalledOnce()
     })
 
-    it('calls onClick when Enter is pressed on the card', async () => {
+    it('calls onClick when Enter is pressed on the primary button', async () => {
         const user = userEvent.setup()
         const onClick = vi.fn()
         renderBlockCard({ onClick })
-        const card = screen.getByRole('button')
-        card.focus()
+        const primaryButton = screen.getByRole('button', { name: /select block threshold 3x8/i })
+        primaryButton.focus()
         await user.keyboard('{Enter}')
         expect(onClick).toHaveBeenCalledOnce()
     })
@@ -139,7 +139,8 @@ describe('BlockCard', () => {
 
     it('applies a selected border when isSelected is true', () => {
         const { container } = renderBlockCard({ isSelected: true })
-        const card = container.querySelector('[role="button"]')!
+        // The outer wrapper div carries the selection styling
+        const card = container.firstElementChild!
         expect(card.className).toContain('border-brand-500')
     })
 })


### PR DESCRIPTION
## Summary

- Removes `div[role="button"]` pattern from `BlockCard` — replaced with a wrapper `div` containing an absolute-inset-0 `<button>` for the primary card action
- Edit and delete icon buttons are siblings at `z-10`, not nested inside the primary button, fixing the invalid nested-button HTML
- Removes manual `onKeyDown`, `tabIndex={0}`, `role="button"` from the card container — native button semantics handle keyboard activation and screen reader announcement

## Test plan

- [ ] Block cards should be keyboard accessible (Tab to focus, Enter/Space to select)
- [ ] Edit and delete buttons should be reachable independently via Tab
- [ ] No HTML validation errors for nested interactive elements

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)