### PR TITLE
[#154] Intercept 403 in API client and retry after token refresh

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchWithAuth, registerSessionExpiredHandler } from './client.ts'
+
+/**
+ * Unit tests for the fetchWithAuth helper in client.ts.
+ *
+ * These tests verify that the 401 and 403 interceptor correctly attempts a
+ * silent token refresh and retries the original request, and that it invokes
+ * the session-expired handler when the refresh itself fails.
+ */
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    mockFetch.mockReset()
+})
+
+function makeResponse(status: number, body: unknown = {}): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+describe('fetchWithAuth', () => {
+    describe('when the response is successful', () => {
+        it('returns the response without attempting a refresh', async () => {
+            mockFetch.mockResolvedValueOnce(makeResponse(200, { id: '1' }))
+
+            const result = await fetchWithAuth('/workouts')
+
+            expect(result.status).toBe(200)
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+        })
+
+        it('always passes credentials: include', async () => {
+            mockFetch.mockResolvedValueOnce(makeResponse(200))
+
+            await fetchWithAuth('/workouts', { method: 'GET' })
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/workouts',
+                expect.objectContaining({ credentials: 'include' }),
+            )
+        })
+    })
+
+    describe('when the response is 401', () => {
+        it('attempts a refresh and retries the original request', async () => {
+            // First call: the protected endpoint returns 401
+            mockFetch.mockResolvedValueOnce(makeResponse(401))
+            // Second call: the refresh endpoint succeeds
+            mockFetch.mockResolvedValueOnce(makeResponse(200, { accessToken: 'new-token' }))
+            // Third call: the retried original request succeeds
+            mockFetch.mockResolvedValueOnce(makeResponse(200, { id: '1' }))
+
+            const result = await fetchWithAuth('/workouts')
+
+            expect(result.status).toBe(200)
+            expect(mockFetch).toHaveBeenCalledTimes(3)
+        })
+
+        it('invokes the session-expired handler and returns the 401 when refresh fails', async () => {
+            const sessionExpiredHandler = vi.fn()
+            registerSessionExpiredHandler(sessionExpiredHandler)
+
+            // First call: the protected endpoint returns 401
+            mockFetch.mockResolvedValueOnce(makeResponse(401))
+            // Second call: the refresh endpoint also fails
+            mockFetch.mockResolvedValueOnce(makeResponse(403))
+
+            const result = await fetchWithAuth('/workouts')
+
+            expect(result.status).toBe(401)
+            expect(sessionExpiredHandler).toHaveBeenCalledTimes(1)
+            // No retry of the original request after a failed refresh
+            expect(mockFetch).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe('when the response is 403', () => {
+        it('attempts a refresh and retries the original request', async () => {
+            // First call: the protected endpoint returns 403 (expired access token)
+            mockFetch.mockResolvedValueOnce(makeResponse(403))
+            // Second call: the refresh endpoint succeeds
+            mockFetch.mockResolvedValueOnce(makeResponse(200, { accessToken: 'new-token' }))
+            // Third call: the retried original request succeeds
+            mockFetch.mockResolvedValueOnce(makeResponse(200, { id: '1' }))
+
+            const result = await fetchWithAuth('/workouts', { method: 'POST' })
+
+            expect(result.status).toBe(200)
+            expect(mockFetch).toHaveBeenCalledTimes(3)
+        })
+
+        it('retries with the same method and options', async () => {
+            const body = JSON.stringify({ name: 'Test Workout' })
+
+            mockFetch.mockResolvedValueOnce(makeResponse(403))
+            mockFetch.mockResolvedValueOnce(makeResponse(200, { accessToken: 'new-token' }))
+            mockFetch.mockResolvedValueOnce(makeResponse(201, { id: '42' }))
+
+            await fetchWithAuth('/workouts', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body,
+            })
+
+            // The third call is the retry — it should use the same options
+            const retryCall = mockFetch.mock.calls[2]
+            expect(retryCall[0]).toBe('/workouts')
+            expect(retryCall[1]).toMatchObject({
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body,
+            })
+        })
+
+        it('invokes the session-expired handler and returns the 403 when refresh fails', async () => {
+            const sessionExpiredHandler = vi.fn()
+            registerSessionExpiredHandler(sessionExpiredHandler)
+
+            // First call: the protected endpoint returns 403
+            mockFetch.mockResolvedValueOnce(makeResponse(403))
+            // Second call: the refresh endpoint also returns 403 (refresh token expired)
+            mockFetch.mockResolvedValueOnce(makeResponse(403))
+
+            const result = await fetchWithAuth('/workouts')
+
+            expect(result.status).toBe(403)
+            expect(sessionExpiredHandler).toHaveBeenCalledTimes(1)
+            // No retry after a failed refresh
+            expect(mockFetch).toHaveBeenCalledTimes(2)
+        })
+
+        it('does not retry more than once', async () => {
+            mockFetch.mockResolvedValueOnce(makeResponse(403))
+            mockFetch.mockResolvedValueOnce(makeResponse(200, { accessToken: 'new-token' }))
+            // The retried request also returns 403 — should not trigger another refresh
+            mockFetch.mockResolvedValueOnce(makeResponse(403))
+
+            const result = await fetchWithAuth('/workouts')
+
+            // Should stop after the one retry — no third refresh attempt
+            expect(result.status).toBe(403)
+            expect(mockFetch).toHaveBeenCalledTimes(3)
+        })
+    })
+
+    describe('when the response is a non-auth error', () => {
+        it('returns the response without attempting a refresh', async () => {
+            mockFetch.mockResolvedValueOnce(makeResponse(404))
+
+            const result = await fetchWithAuth('/workouts/missing')
+
+            expect(result.status).toBe(404)
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+        })
+
+        it('returns 500 responses without attempting a refresh', async () => {
+            mockFetch.mockResolvedValueOnce(makeResponse(500))
+
+            const result = await fetchWithAuth('/workouts')
+
+            expect(result.status).toBe(500)
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -50,31 +50,40 @@ async function attemptRefresh(): Promise<boolean> {
 }
 
 /**
+ * Returns true if the response status indicates an expired access token.
+ * The backend returns 403 when the JWT has expired and 401 when no credentials
+ * are present at all. Both should trigger a silent refresh attempt.
+ */
+function isTokenExpiredResponse(status: number): boolean {
+    return status === 401 || status === 403
+}
+
+/**
  * Authenticated fetch wrapper that silently refreshes the access token
- * on 401 responses and retries the original request once.
+ * on 401 or 403 responses and retries the original request once.
  *
  * All API calls to protected endpoints should use this function instead
  * of calling fetch directly. It handles:
  * - Adding credentials: 'include' for HttpOnly cookie auth
- * - Detecting 401 (expired access token) and attempting a silent refresh
+ * - Detecting 401/403 (expired access token) and attempting a silent refresh
  * - Retrying the original request after a successful refresh
  * - Calling the session-expired handler if the refresh fails
  *
  * @param url the request URL
  * @param options fetch options (credentials: 'include' is added automatically)
  * @returns the fetch Response
- * @throws Error if the request fails for a non-401 reason
+ * @throws Error if the request fails for a non-auth reason
  */
 export async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
     const mergedOptions: RequestInit = { ...options, credentials: 'include' }
 
     const response = await fetch(url, mergedOptions)
 
-    if (response.status !== 401) {
+    if (!isTokenExpiredResponse(response.status)) {
         return response
     }
 
-    // 401 received: attempt a silent token refresh
+    // 401 or 403 received: attempt a silent token refresh
     const refreshed = await attemptRefresh()
 
     if (!refreshed) {


### PR DESCRIPTION
## Summary

- Extends `fetchWithAuth` in `src/api/client.ts` to treat HTTP 403 (token expired) the same as 401 — attempts a silent token refresh and retries the original request once
- Adds `isTokenExpiredResponse(status)` helper to keep the condition in one place
- Adds 8 unit tests covering: successful pass-through, 401 refresh+retry, 403 refresh+retry, failed refresh → session-expired handler, retry preserves original method/headers/body, no double-retry, non-auth errors pass through

## Test plan

- [ ] Let a session token expire naturally — the next API call should silently refresh and succeed rather than logging out
- [ ] If the refresh token is also expired, the session-expired handler should fire (modal or redirect)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)